### PR TITLE
Do not build the library in musl

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -97,6 +97,8 @@ let
           muslHaskellPackages.ic-hs.overrideAttrs (
             old: {
               configureFlags = [
+                "-frelease"
+                "-f-library"
                 "--ghc-option=-optl=-static"
                 "--extra-lib-dirs=${nixpkgs.pkgsMusl.zlib.static}/lib"
                 "--extra-lib-dirs=${nixpkgs.pkgsMusl.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"

--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -11,6 +11,10 @@ flag release
   default: False
   description: Release build, warnings are errors
 
+flag library
+  default: True
+  description: Build library (useful to disable in musl builds)
+
 -- NB: It might look odd that we are replicating the module lists between
 -- the various executables and the library.
 --
@@ -462,6 +466,10 @@ test-suite unit-test
 
 library
   import: cbits, ghc-flags
+
+  if !flag(library)
+    buildable: False
+
   build-depends: aeson
   build-depends: asn1-encoding
   build-depends: asn1-types


### PR DESCRIPTION
it fails with
```
/nix/store/cdbsfljc8m900axs37fab7gnp2y1dksn-binutils-2.31.1/bin/ld: /nix/store/x0ybqvkk6h6x8mhsy5gghplsfvammq6q-gcc-9.3.0/lib/gcc/x86_64-unknown-linux-musl/9.3.0/crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
/nix/store/cdbsfljc8m900axs37fab7gnp2y1dksn-binutils-2.31.1/bin/ld: /nix/store/x0ybqvkk6h6x8mhsy5gghplsfvammq6q-gcc-9.3.0/lib/gcc/x86_64-unknown-linux-musl/9.3.0/crtend.o: relocation R_X86_64_32 against `.ctors' can not be used when making a shared object; recompile with -fPIC
/nix/store/cdbsfljc8m900axs37fab7gnp2y1dksn-binutils-2.31.1/bin/ld: final link failed: nonrepresentable section on output
collect2: error: ld returned 1 exit status
`cc' failed in phase `Linker'. (Exit code: 1)
builder for '/nix/store/5k44cpmxgcsjk6jxv3a7hw8rfa8m1bmw-ic-hs-0.0.1.drv' failed with exit code 1
```
and I didn't bother investigating.