### PR TITLE
ic-ref-run: Pretty print candid values without type table

### DIFF
--- a/src/ic-ref-run.hs
+++ b/src/ic-ref-run.hs
@@ -78,7 +78,7 @@ printReqResponse (ReadStateResponse _ ) = error "dead code in ic-ref"
 candidOrPretty :: Blob -> String
 candidOrPretty b
   | BC.pack "DIDL" `B.isPrefixOf` b
-  , Right vs <- Candid.decodeVals b
+  , Right (_, vs) <- Candid.decodeVals b
   = show (pretty vs)
   | otherwise
   = "(" ++ prettyBlob b ++ ")"


### PR DESCRIPTION
fixes #21