### PR TITLE
Github actions: Run nix action on pull requests, too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: "Nix builds"
 on:
   push:
+     branches: [ master ]
+  pull_request: {}
 jobs:
   test:
     strategy:


### PR DESCRIPTION
and restrict build-on-push to master, to not run the job twice on PRs
from within the repo.