### PR TITLE
Configure mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,23 @@
+pull_request_rules:
+  - name: Automatic merge (squash)
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - status-success=test (ubuntu-latest)
+      - status-success=test (macos-latest)
+      - base=master
+      - label=automerge-squash
+    actions:
+      merge:
+        method: squash
+        strict: smart
+        commit_message: title+body
+      delete_head_branch: {}
+  - name: Clean up automerge tags
+    conditions:
+      - closed
+    actions:
+      label:
+        remove:
+        - automerge-squash
+        - autoclose


### PR DESCRIPTION
this adds a mergify configuration to the repo, fixing #33.

TL;DR: Label a PR with `automerge-squash` and it will be merged once
approved an green. Also, mergify will update out-of-date branches as
`master` changes.

It is based on the `.mergify.yaml` from Motoko, but omitting the “fancy”
features (e.g. approving changelog changes and dependency bumps). We can
add them when and if we add auto dependency bumping, but we don’t have
that many dependencies, so maybe not needed.