### PR TITLE
Remove .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-eval "$(lorri direnv)"


### PR DESCRIPTION
Everyone doesn't use `lorri` (or Nix), which means in most cases `direnv` will just die. People will also want to use their own `.envrc`.