### PR TITLE
[VER-1123] Implement metadata access

### DIFF
--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -336,6 +336,7 @@ executable ic-ref-test
   other-modules: IC.Test.Universal
   other-modules: IC.Types
   other-modules: IC.Version
+  other-modules: IC.Utils
   other-modules: SourceId
 
 executable ic-request-id
@@ -367,6 +368,7 @@ executable ic-request-id
   other-modules: IC.Id.Forms
   other-modules: IC.Types
   other-modules: IC.Version
+  other-modules: IC.Utils
   other-modules: SourceId
 
 test-suite unit-test

--- a/src/IC/Canister/Imp.hs
+++ b/src/IC/Canister/Imp.hs
@@ -26,7 +26,6 @@ module IC.Canister.Imp
 where
 
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Lazy.Char8 as BSC
 import qualified Data.ByteString.Lazy.UTF8 as BSU
@@ -45,6 +44,7 @@ import IC.Constants
 import IC.Wasm.Winter
 import IC.Wasm.Imports
 import IC.Canister.StableMemory as Mem
+import IC.Utils
 
 -- Parameters are the data that come from the caller
 
@@ -509,7 +509,7 @@ systemAPI esref =
     (msg_method_name_size, msg_method_name_copy) = size_and_copy $
       gets method_name >>=
         maybe (throwError "Cannot query method name here")
-              (return . BS.fromStrict . T.encodeUtf8 . T.pack)
+              (return . toUtf8 . T.pack)
 
     accept_message :: () -> HostM s ()
     accept_message () = do

--- a/src/IC/Certificate/Value.hs
+++ b/src/IC/Certificate/Value.hs
@@ -4,12 +4,12 @@
 module IC.Certificate.Value (CertVal(..)) where
 
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import qualified Data.ByteString.Lazy as BS
 import Data.Serialize.LEB128
 import Numeric.Natural
 
 import IC.Types
+import IC.Utils
 
 class CertVal a where
      toCertVal :: a -> Blob
@@ -20,8 +20,8 @@ instance CertVal Blob where
     fromCertVal = Just
 
 instance CertVal T.Text where
-    toCertVal = BS.fromStrict . T.encodeUtf8
-    fromCertVal = forgetLeft . T.decodeUtf8' . BS.toStrict
+    toCertVal = toUtf8
+    fromCertVal = fromUtf8
 
 instance CertVal Natural where
     toCertVal = BS.fromStrict . toLEB128

--- a/src/IC/Crypto/WebAuthn.hs
+++ b/src/IC/Crypto/WebAuthn.hs
@@ -29,10 +29,7 @@ import qualified Data.Aeson.Types as JSON
 import qualified IC.HTTP.CBOR as CBOR
 import Codec.CBOR.Term
 import Codec.CBOR.Write (toLazyByteString)
-import IC.CBOR.Parser
 import qualified Data.Map as M
-import IC.HTTP.GenR.Parse
-import IC.Hash
 import Control.Monad.Except
 import qualified Crypto.PubKey.ECC.ECDSA as EC
 import qualified Crypto.PubKey.ECC.Generate as EC
@@ -46,12 +43,17 @@ import Crypto.Hash.Algorithms (SHA256(..))
 import Data.ASN1.Types
 import Data.ASN1.Encoding
 import Data.ASN1.BinaryEncoding
+
+import IC.CBOR.Parser
+import IC.HTTP.GenR.Parse
+import IC.Hash
 import IC.Crypto.DER.Decode
+import IC.Utils
 
 parseSig :: BS.ByteString -> Either T.Text (BS.ByteString, BS.ByteString, BS.ByteString)
 parseSig = CBOR.decode >=> record do
       ad <- field blob "authenticator_data"
-      cdj <- BS.fromStrict . T.encodeUtf8 <$> field text "client_data_json"
+      cdj <- toUtf8 <$> field text "client_data_json"
       sig <- field blob "signature"
       return (ad, cdj, sig)
 

--- a/src/IC/HTTP/RequestId.hs
+++ b/src/IC/HTTP/RequestId.hs
@@ -1,14 +1,15 @@
 module IC.HTTP.RequestId (requestId) where
 
 import Numeric.Natural
-import IC.HTTP.GenR
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import Data.List (sort)
 import Data.Serialize.LEB128
+
+import IC.HTTP.GenR
 import IC.Hash
+import IC.Utils
 
 type RequestId = BS.ByteString
 
@@ -17,17 +18,14 @@ requestId (GRec hm) = sha256 $ BS.concat $ sort $ map encodeKV $ HM.toList hm
 requestId _ = error "requestID: expected a record"
 
 encodeKV :: (T.Text, GenR) -> BS.ByteString
-encodeKV (k,v) = sha256 (encodeText k) <> sha256 (encodeVal v)
+encodeKV (k,v) = sha256 (toUtf8 k) <> sha256 (encodeVal v)
 
 encodeVal :: GenR -> BS.ByteString
 encodeVal (GBlob b) = b
-encodeVal (GText t) = encodeText t
+encodeVal (GText t) = toUtf8 t
 encodeVal (GNat n) = encodeNat n
 encodeVal (GRec _) = error "requestID: Nested record"
 encodeVal (GList vs) = BS.concat $ map (sha256 . encodeVal) vs
-
-encodeText :: T.Text -> BS.ByteString
-encodeText = BS.fromStrict . T.encodeUtf8
 
 encodeNat :: Natural -> BS.ByteString
 encodeNat = BS.fromStrict . toLEB128

--- a/src/IC/Utils.hs
+++ b/src/IC/Utils.hs
@@ -6,6 +6,11 @@ don’t want to see in non-plumbing code.
 module IC.Utils where
 
 import qualified Data.Map as M
+import qualified Data.Set as S
+import qualified Data.ByteString.Lazy as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
 
 freshKey :: M.Map Int a -> Int
 freshKey m | M.null m = 0
@@ -16,3 +21,21 @@ repeatWhileTrue act = act >>= \case
     True -> repeatWhileTrue act
     False -> return ()
 
+
+duplicates :: Ord a => [a] -> [a]
+duplicates = go S.empty
+  where
+    go _s [] = []
+    go s (x:xs) | x `S.member` s = x : go s' xs
+                | otherwise      =     go s' xs
+      where s' = S.insert x s
+
+
+-- Wrappers to hide strict/lazy conversion from view
+toUtf8 :: T.Text -> BS.ByteString
+toUtf8 = BS.fromStrict . T.encodeUtf8
+
+fromUtf8 :: BS.ByteString -> Maybe T.Text
+fromUtf8 b = case T.decodeUtf8' (BS.toStrict b) of
+    Left _ -> Nothing
+    Right t -> Just t


### PR DESCRIPTION
this is a reimplementation of @jwiegley’s #53; his PR gave me many ideas
that I felt would be very tedious and impolite to convey through prose
review, so I just wrote down how I would do it. I hope this achieves the
level of declaratively that we aim for (by moving plumbing code into
other modules, for example, and by having more precise types.)

In addition to #53, this performs more module validation, and adds
further tests, and fixes a bug where deleted canisters still show up in
the state tree (probably worth refactoring to avoid such bugs, but not
in this PR).