### PR TITLE
ic-ref-test: Test inter-canister calls to user’s principals

### DIFF
--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -809,6 +809,9 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
     , simpleTestCase "to nonexistant canister" $ \cid ->
       call cid (inter_call "foo" "bar" defArgs) >>= isRelay >>= isReject [3]
 
+    , simpleTestCase "to nonexistant canister (user id)" $ \cid ->
+      call cid (inter_call defaultUser "bar" defArgs) >>= isRelay >>= isReject [3]
+
     , simpleTestCase "to nonexistant method" $ \cid ->
       call cid (inter_call cid "bar" defArgs) >>= isRelay >>= isReject [3]
 


### PR DESCRIPTION
these should be treated like calls to non-existant canisters, and it
doesn’t hurt to test that