### PR TITLE
Update system API for 128 bit cycles tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ let universal-canister = (naersk.buildPackage rec {
     src = subpath ./universal-canister;
     root = ./universal-canister;
     CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_LINKER = "${nixpkgs.llvmPackages_12.lld}/bin/lld";
-    RUSTFLAGS = "-C link-arg=-s -C target-feature=+multivalue"; # much smaller wasm
+    RUSTFLAGS = "-C link-arg=-s"; # much smaller wasm
     cargoBuildOptions = x : x ++ [ "--target wasm32-unknown-unknown" ];
     doCheck = false;
     release = true;

--- a/src/IC/Canister/Imp.hs
+++ b/src/IC/Canister/Imp.hs
@@ -27,10 +27,10 @@ module IC.Canister.Imp
 where
 
 import qualified Data.Text as T
+import qualified Data.ByteString.Builder as BS
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Lazy.Char8 as BSC
 import qualified Data.ByteString.Lazy.UTF8 as BSU
-import qualified Data.Binary.Put as Put
 import Control.Monad.Primitive
 import Control.Monad.ST
 import Control.Monad.Except
@@ -364,9 +364,7 @@ systemAPI esref =
     lowBits = fromIntegral . (0xFFFFFFFF_FFFFFFFF .&.)
 
     to128le :: Natural -> BS.ByteString
-    to128le n = Put.runPut $ do
-      Put.putWord64le (lowBits n)
-      Put.putWord64le (highBits n)
+    to128le n = BS.toLazyByteString $ BS.word64LE (lowBits n) <> BS.word64LE (highBits n)
 
     combineBitHalves :: (Word64, Word64) -> Natural
     combineBitHalves (high, low) = fromIntegral high `shiftL` 64 .|. fromIntegral low

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -527,8 +527,11 @@ asWord64 = runGet Get.getWord64le
 as2Word64 :: HasCallStack => Blob -> IO (Word64, Word64)
 as2Word64 = runGet $ (,) <$> Get.getWord64le <*> Get.getWord64le
 
-asPairWord64 :: HasCallStack => Blob -> IO (Word64, Word64)
-asPairWord64 = runGet $ flip (,) <$> Get.getWord64le <*> Get.getWord64le
+asWord128 :: HasCallStack => Blob -> IO Natural
+asWord128 = runGet $ do
+    low <- Get.getWord64le
+    high <- Get.getWord64le
+    return $ fromIntegral high `shiftL` 64 .|. fromIntegral low
 
 bothSame :: (Eq a, Show a) => (a, a) -> Assertion
 bothSame (x,y) = x @?= y
@@ -843,6 +846,3 @@ textual = T.unpack . prettyPrincipal . Principal
 shorten :: Int -> String -> String
 shorten n s = a ++ (if null b then "" else "…")
   where (a,b) = splitAt n s
-
-toI128 :: (Word64, Word64) -> Natural
-toI128 (high, low) = fromIntegral high `shiftL` 64 .|. fromIntegral low

--- a/src/IC/Test/Universal.hs
+++ b/src/IC/Test/Universal.hs
@@ -26,8 +26,7 @@ import Data.String
 
 -- The types of our little language are i32, i64, pair of i64s and blobs
 
-data T = I | I64 | B | PairI64
-
+data T = I | I64 | B
 
 -- We deal with expressions (return a value, thus have a type) and programs (do
 -- something, but do not return a type). They are represented simply
@@ -228,23 +227,20 @@ onHeartbeat = op 49
 performanceCounter :: Exp 'I64
 performanceCounter = op 50
 
-getBalance128 :: Exp 'PairI64
+getBalance128 :: Exp 'B
 getBalance128 = op 51
 
-getAvailableCycles128 :: Exp 'PairI64
+getAvailableCycles128 :: Exp 'B
 getAvailableCycles128 = op 52
 
-getRefund128 :: Exp 'PairI64
+getRefund128 :: Exp 'B
 getRefund128 = op 53
 
-acceptCycles128 :: Exp 'I64 -> Exp 'I64 -> Exp 'PairI64
+acceptCycles128 :: Exp 'I64 -> Exp 'I64 -> Exp 'B
 acceptCycles128 = op 54
 
 callCyclesAdd128 :: Exp 'I64 -> Exp 'I64 -> Prog
 callCyclesAdd128 = op 55
-
-pairToB :: Exp 'PairI64 -> Exp 'B
-pairToB = op 56
 
 -- Some convenience combinators
 

--- a/universal-canister/src/api.rs
+++ b/universal-canister/src/api.rs
@@ -1,24 +1,8 @@
-use std::convert::{TryInto};
-
 // use `wee_alloc` as the global allocator.
 extern crate wee_alloc;
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc<'_> = wee_alloc::WeeAlloc::INIT;
-
-#[repr(C)]
-// Note: tuples are not FFI-safe causing the compiler to complain. To avoid this,
-// we represent pair as a tuple struct which has known memory layout and the same semantics as
-// a plain pair.
-pub struct Pair(pub u64, pub u64);
-
-impl Pair {
-    pub fn new(input: u128) -> Self {
-        let high = (input >> 64) as u64;
-        let low = (input & 0xffff_ffff_ffff_ffff) as u64;
-        Self(high, low)
-    }
-}
 
 mod ic0 {
     #[link(wasm_import_module = "ic0")]
@@ -203,44 +187,44 @@ pub fn cycles_available() -> u64 {
     unsafe { ic0::msg_cycles_available() }
 }
 
-pub fn cycles_available128() -> Pair {
+pub fn cycles_available128() -> Vec<u8> {
     let size = 16;
     let mut bytes = vec![0u8; size];
     unsafe { ic0::msg_cycles_available128(bytes.as_mut_ptr() as u32) }
-    Pair::new(u128::from_le_bytes(bytes.try_into().unwrap()))
+    bytes
 }
 
 pub fn cycles_refunded() -> u64 {
     unsafe { ic0::msg_cycles_refunded() }
 }
 
-pub fn cycles_refunded128() -> Pair {
+pub fn cycles_refunded128() -> Vec<u8> {
     let size = 16;
     let mut bytes = vec![0u8; size];
     unsafe { ic0::msg_cycles_refunded128(bytes.as_mut_ptr() as u32) }
-    Pair::new(u128::from_le_bytes(bytes.try_into().unwrap()))
+    bytes
 }
 
 pub fn accept(amount: u64) -> u64 {
     unsafe { ic0::msg_cycles_accept(amount) }
 }
 
-pub fn accept128(high: u64, low: u64) -> Pair {
+pub fn accept128(high: u64, low: u64) -> Vec<u8> {
     let size = 16;
     let mut bytes = vec![0u8; size];
     unsafe { ic0::msg_cycles_accept128(high, low, bytes.as_mut_ptr() as u32) }
-    Pair::new(u128::from_le_bytes(bytes.try_into().unwrap()))
+    bytes
 }
 
 pub fn balance() -> u64 {
     unsafe { ic0::canister_cycle_balance() }
 }
 
-pub fn balance128() -> Pair {
+pub fn balance128() -> Vec<u8> {
     let size = 16;
     let mut bytes = vec![0u8; size];
     unsafe { ic0::canister_cycle_balance128(bytes.as_mut_ptr() as u32) }
-    Pair::new(u128::from_le_bytes(bytes.try_into().unwrap()))
+    bytes
 }
 
 pub fn stable_size() -> u32 {

--- a/universal-canister/src/api.rs
+++ b/universal-canister/src/api.rs
@@ -14,8 +14,8 @@ pub struct Pair(pub u64, pub u64);
 
 impl Pair {
     pub fn new(input: u128) -> Self {
-        let low = (input >> 64) as u64;
-        let high = (input & 0xffff_ffff_ffff_ffff) as u64;
+        let high = (input >> 64) as u64;
+        let low = (input & 0xffff_ffff_ffff_ffff) as u64;
         Self(high, low)
     }
 }

--- a/universal-canister/src/main.rs
+++ b/universal-canister/src/main.rs
@@ -8,7 +8,6 @@ enum Val {
     I32(u32),
     I64(u64),
     Blob(Vec<u8>),
-    PairI64(api::Pair),
 }
 
 struct Stack(Vec<Val>);
@@ -34,10 +33,6 @@ impl Stack {
         self.0.push(Val::Blob(x));
     }
 
-    fn push_pair_int64(self: &mut Self, p: api::Pair) {
-        self.0.push(Val::PairI64(p));
-    }
-
     fn pop_int(self: &mut Self) -> u32 {
         if let Some(Val::I32(i)) = self.0.pop() {
             i
@@ -59,14 +54,6 @@ impl Stack {
             blob
         } else {
             api::trap_with("did not find blob on stack")
-        }
-    }
-
-    fn pop_pair_int64(self: &mut Self) -> api::Pair {
-        if let Some(Val::PairI64(p)) = self.0.pop() {
-            p
-        } else {
-            api::trap_with("did not find pair of I64s on stack")
         }
     }
 }
@@ -301,32 +288,24 @@ fn eval(ops: Ops) {
 
             // 128-bit cycles API
             51 => {
-                stack.push_pair_int64(api::balance128())
+                stack.push_blob(api::balance128())
             },
             52 => {
-                stack.push_pair_int64(api::cycles_available128())
+                stack.push_blob(api::cycles_available128())
             },
             53 => {
-                stack.push_pair_int64(api::cycles_refunded128())
+                stack.push_blob(api::cycles_refunded128())
             },
             54 => {
                 let low = stack.pop_int64();
                 let high = stack.pop_int64();
-                stack.push_pair_int64(api::accept128(high, low))
+                stack.push_blob(api::accept128(high, low))
             },
             55 => {
                 let low = stack.pop_int64();
                 let high = stack.pop_int64();
                 api::call_cycles_add128(high, low)
             },
-
-            // pair to blob
-            56 => {
-                let p = stack.pop_pair_int64();
-                let mut bytes = p.1.to_le_bytes().to_vec();
-                bytes.append(&mut p.0.to_le_bytes().to_vec());
-                stack.push_blob(bytes)
-            }
 
             _ => api::trap_with(&format!("unknown op {}", op)),
         }


### PR DESCRIPTION
Following up on our discussion regarding the multivalue target feature support, we have decided to update the experimental System Api and not rely on this feature anymore.

This MR updates the tests according to the Public Spec.