### PR TITLE
ic-ref-test: Test stopping state

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ For `ic-ref-test`, before running it, you make sure you have built the universal
 The symbolic link in `test-data/universal_canister.wasm` points to the
 build output produced by
 
-    cd universal_canister
+    cd universal-canister
     nix-shell --command 'cargo build --target wasm32-unknown-unknown --release'
 
 You can now run the test suite from the top-level directory with

--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -744,7 +744,7 @@ processMessage m = case m of
           -- This is a hack, detecting callbacks via the entry, and demands refactoring
           _ -> reject RC_CANISTER_ERROR "canister is not running"
       empty <- isCanisterEmpty callee
-      when empty $ reject RC_DESTINATION_INVALID "canister is empty" -- TODO: what to do for callbacks
+      when empty $ reject RC_DESTINATION_INVALID "canister is empty" -- NB: An empty canister cannot receive a callback.
       wasm_state <- getCanisterState callee
       can_mod <- getCanisterMod callee
       env <- canisterEnv callee

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -201,9 +201,9 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
           , "arg" =: GBlob (run messageHold)
           ]
       grs1 >>= isPendingOrProcessing
-      
+
       step "Normal call (to sync)"
-      call_ cid reply 
+      call_ cid reply
 
       step "Stop"
       grs2 <- submitCall cid $ rec
@@ -2712,8 +2712,9 @@ createMessageHold = do
             callNew "" "stop_canister" (callback (trap "createMessageHold: stopping succeeded?")) (callback reply) >>>
             callDataAppend (bytes (Candid.encode (#canister_id .== Principal cid))) >>>
             callPerform
+        , on_reply = reply
         }
   let release = ic_start_canister ic00 cid
   return (holdMessage, release)
-    
+
 


### PR DESCRIPTION
This allows the test driver to withhold the response to a message, and
control when they are released, in order to produce situations with
outstanding call contexts.

In an ideal world (from our pov), we could instrument and control the
system's scheduler this way, but we can't. So instead, we use some tricks.
Ideally, the details of this trick are irrelevant to the users of this
function (yay, abstraction), and if we find better tricks, we can swap them
out easily. We'll see if that holds water.

One problem with this approach is that a test failure could mean that the
system doesn't pass the test, but it could also mean that the system has a
bug that prevents this trick from working, so take care.

The current trick is: Create a canister (the "stopper"). Make it its own
controller. Tell the canister to stop itself. This call will now hang,
because a canister cannot stop itself. We can release the call (producing a
reject) by starting the canister again.

Some tests are added, and others are now using this mechanism.

This has uncovered bugs in `ic-ref` related to the handling of stopped.