### PR TITLE
Github Actions: Disable fast failing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         - ubuntu-latest
         - macos-latest
         # TODO: - windows-latest
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
especially during maintenance work like in #64 it is useful to keep
running the test on one arch even if the other is failing.