### PR TITLE
feat: support gzip-compressed canister modules

### DIFF
--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -222,6 +222,7 @@ executable ic-ref-run
   build-depends: vector
   build-depends: winter
   build-depends: uglymemo
+  build-depends: zlib
   other-modules: IC.Canister
   other-modules: IC.Canister.Imp
   other-modules: IC.Canister.Snapshot
@@ -316,6 +317,7 @@ executable ic-ref-test
   build-depends: vector
   build-depends: wai
   build-depends: warp
+  build-depends: zlib
   other-modules: IC.CBOR.Parser
   other-modules: IC.CBOR.Patterns
   other-modules: IC.CBOR.Utils

--- a/src/IC/Canister.hs
+++ b/src/IC/Canister.hs
@@ -16,10 +16,13 @@ module IC.Canister
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import qualified Data.ByteString.Lazy.Char8 as BS
+import Data.Char (chr)
 import Data.List
 import Control.Monad
 import Data.Foldable
 import Control.Monad.Except
+import Codec.Compression.GZip (decompress)
 
 import IC.Types
 import IC.Wasm.Winter (parseModule, exportedFunctions, Module)
@@ -59,9 +62,20 @@ data CanisterModule = CanisterModule
 instance Show CanisterModule where
     show _ = "CanisterModule{...}"
 
+decodeModule :: Blob -> Either String Blob
+decodeModule bytes =
+  if | asmMagic `BS.isPrefixOf` bytes -> Right bytes
+     | gzipMagic `BS.isPrefixOf` bytes -> Right $ decompress bytes
+     | otherwise -> throwError $ "Unsupported module encoding"
+  where
+    asBytes = BS.pack . map chr
+    asmMagic = asBytes [0x00, 0x61, 0x73, 0x6d]
+    gzipMagic = asBytes [0x1f, 0x8b, 0x08]
+
 parseCanister :: Blob -> Either String CanisterModule
 parseCanister bytes = do
-  wasm_mod <- either throwError pure (parseModule bytes)
+  decodedModule <- decodeModule bytes
+  wasm_mod <- either throwError pure (parseModule decodedModule)
   let icp_sections =
         [ (icp_name, W._customPayload section)
         | section <- toList (W._moduleCustom wasm_mod)


### PR DESCRIPTION
This change adds support for installing gzip-compressed modules
as specified in https://github.com/dfinity/interface-spec/pull/11