### PR TITLE
feat: allow optional "error_code" field in responses

### DIFF
--- a/src/IC/Debug/JSON.hs
+++ b/src/IC/Debug/JSON.hs
@@ -80,6 +80,11 @@ instance ToJSON RejectCode where
     toJSON     = genericToJSON customOptions
     toEncoding = genericToEncoding customOptions
 
+deriving instance Generic ErrorCode
+instance ToJSON ErrorCode where
+    toJSON     = genericToJSON customOptions
+    toEncoding = genericToEncoding customOptions
+
 deriving instance Generic Response
 instance ToJSON Response where
     toJSON     = genericToJSON customOptions

--- a/src/IC/HTTP/Request.hs
+++ b/src/IC/HTTP/Request.hs
@@ -145,7 +145,8 @@ entitiyId = fmap EntityId <$> blob
 
 -- Printing responses
 response :: ReqResponse -> GenR
-response (QueryResponse (Rejected (c, s))) = rec
+response (QueryResponse (Rejected (c, s, err))) = rec $
+    [ "error_code" =: GText (T.pack $ errorCode c) | c <- maybeToList err] ++
     [ "status" =: GText "rejected"
     , "reject_code" =: GNat (fromIntegral (rejectCode c))
     , "reject_message" =: GText (T.pack s)

--- a/src/IC/Serialise.hs
+++ b/src/IC/Serialise.hs
@@ -47,6 +47,9 @@ instance Serialise NeedsToRespond where
 deriving instance Generic RejectCode
 instance Serialise RejectCode where
 
+deriving instance Generic ErrorCode
+instance Serialise ErrorCode where
+
 deriving instance Generic Response
 instance Serialise Response where
 

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -2692,7 +2692,7 @@ isRelay = runGet $ Get.getWord32le >>= \case
     0x4c444944 -> fail "Encountered Candid when expectin relayed data. Did you forget to use isRelay?"
     c -> do
       msg <- Get.getRemainingLazyByteString
-      return $ Reject (fromIntegral c) (T.decodeUtf8With T.lenientDecode (BS.toStrict msg))
+      return $ Reject (fromIntegral c) (T.decodeUtf8With T.lenientDecode (BS.toStrict msg)) Nothing
 
 
 -- Shortcut for test cases that just need one canister.

--- a/src/IC/Types.hs
+++ b/src/IC/Types.hs
@@ -20,6 +20,7 @@ import Data.List
 import Data.List.Split (chunksOf)
 import Numeric.Natural
 import Control.Monad.Except
+import Text.Printf (printf)
 
 type (↦) = M.Map
 
@@ -72,6 +73,26 @@ rejectCode RC_DESTINATION_INVALID = 3
 rejectCode RC_CANISTER_REJECT     = 4
 rejectCode RC_CANISTER_ERROR      = 5
 
+data ErrorCode
+    = EC_CANISTER_NOT_FOUND
+    | EC_METHOD_NOT_FOUND
+    | EC_CANISTER_EMPTY
+    | EC_CANISTER_NOT_EMPTY
+    | EC_CANISTER_STOPPED
+    | EC_CANISTER_NOT_STOPPED
+    | EC_CANISTER_NOT_RUNNING
+    | EC_CANISTER_RESTARTED
+    | EC_CANISTER_TRAPPED
+    | EC_CANISTER_REJECTED
+    | EC_CANISTER_DID_NOT_REPLY
+    | EC_INVALID_ENCODING
+    | EC_INVALID_ARGUMENT
+    | EC_INVALID_MODULE
+    | EC_NOT_AUTHORIZED
+  deriving (Show, Enum)
+
+errorCode :: ErrorCode -> String
+errorCode = printf "ICHS%04d" . fromEnum
 
 data Response = Reply Blob | Reject (RejectCode, String)
   deriving Show

--- a/src/ic-ref-run.hs
+++ b/src/ic-ref-run.hs
@@ -59,7 +59,7 @@ printQueryRequest (QueryRequest _ _ method arg) =
     printf "→ query %s%s\n" method (shorten 60 (candidOrPretty arg))
 
 printCallResponse :: CallResponse -> IO ()
-printCallResponse (Rejected (c, s)) =
+printCallResponse (Rejected (c, s, _err)) =
     printf "← rejected (%s): %s\n" (show c) s
 printCallResponse (Replied blob) =
     printf "← replied: %s\n" (shorten 100 (candidOrPretty blob))


### PR DESCRIPTION
This change relaxes the ic-ref-test suite to allow optional "error_code"
field in query responses and in request statuses as described in
https://github.com/dfinity/interface-spec/pull/38