### PR TITLE
fix: mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,7 +21,7 @@ pull_request_rules:
       queue:
         method: squash
         name: default
-        commit_message_template:
+        commit_message_template: |
           {{title}}
 
           {{body}}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,7 +21,10 @@ pull_request_rules:
       queue:
         method: squash
         name: default
-        commit_message: title+body
+        commit_message_template:
+          {{title}}
+
+          {{body}}
       delete_head_branch: {}
   - name: Clean up automerge tags
     conditions:


### PR DESCRIPTION
Mergify changed their `commit_message` option to `commit_message_template`. 
See: https://docs.mergify.com/actions/queue/#id2