### PR TITLE
Use nixbuild.net as a remote nix builder on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,45 +11,24 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        # TODO: - macos-latest
-        # TODO: - windows-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - name: Configure SSH such that GitHub can authenticate with nixbuild.net
-      run: |
-        sudo mkdir -p -m 700 /root/.ssh
-
-        sudo touch /root/.ssh/nixbuild_id
-        sudo chmod 600 /root/.ssh/nixbuild_id
-        cat << EOF | sudo tee /root/.ssh/nixbuild_id > /dev/null
-        ${{ secrets.SSH_KEY_FOR_NIXBUILD }}
-        EOF
-
-        sudo touch /root/.ssh/config
-        sudo chmod 600 /root/.ssh/config
-        cat << EOF | sudo tee --append /root/.ssh/config > /dev/null
-        Host eu.nixbuild.net
-          PubkeyAcceptedKeyTypes ssh-ed25519
-          IdentityFile /root/.ssh/nixbuild_id
-        EOF
-
-        echo 'eu.nixbuild.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPIQCZc54poJ8vqawd8TraNryQeJnvH1eLpIDgbiqymM' \
-          | sudo tee --append /etc/ssh/ssh_known_hosts > /dev/null
-
-    - uses: cachix/install-nix-action@v16
+    - uses: nixbuild/nix-quick-install-action@v13
       with:
-        extra_nix_config: |
-          experimental-features = nix-command
+        nix_conf: experimental-features = nix-command
+    - uses: nixbuild/nixbuild-action@v10
+      with:
+        nixbuild_ssh_key: ${{ secrets.SSH_KEY_FOR_NIXBUILD }}
+    - run: nix-env -iA nix-build-uncached -f nix/
     - uses: cachix/cachix-action@v10
       with:
         name: ic-hs-test
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-    # TODO: we might not need this if we go for remote store builds in nixbuild.net
     # until https://github.com/cachix/cachix-action/issues/86 is fixed:
-    #- run: cachix watch-store ic-hs-test &
+    - run: cachix watch-store ic-hs-test &
 
     # run a few targets explicitly, to get easier signal in the CI view
     - run: nix-build-uncached -A universal-canister
@@ -77,7 +56,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v16
+    - uses: nixbuild/nix-quick-install-action@v13
+    - uses: nixbuild/nixbuild-action@v10
+      with:
+        nixbuild_ssh_key: ${{ secrets.SSH_KEY_FOR_NIXBUILD }}
     - uses: cachix/cachix-action@v10
       with:
         name: ic-hs-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,15 @@ jobs:
         # - macos-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    env:
+      SSH_KEY_FOR_NIXBUILD: secrets.SSH_KEY_FOR_NIXBUILD
     steps:
     - uses: actions/checkout@v2
     - uses: nixbuild/nix-quick-install-action@v13
       with:
         nix_conf: experimental-features = nix-command
-    - if: ${{ secrets.SSH_KEY_FOR_NIXBUILD != '' }}
+    - name: Configure Nix to use nixbuild.net as a remote builder
+      if: env.SSH_KEY_FOR_NIXBUILD != ''
       uses: nixbuild/nixbuild-action@v10
       with:
         nixbuild_ssh_key: ${{ secrets.SSH_KEY_FOR_NIXBUILD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: nixbuild/nix-quick-install-action@v13
       with:
         nix_conf: experimental-features = nix-command
-    - if: ${{ secrets.SSH_KEY_FOR_NIXBUILD }} != ""
+    - if: ${{ secrets.SSH_KEY_FOR_NIXBUILD != '' }}
       uses: nixbuild/nixbuild-action@v10
       with:
         nixbuild_ssh_key: ${{ secrets.SSH_KEY_FOR_NIXBUILD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         EOF
 
         echo 'eu.nixbuild.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPIQCZc54poJ8vqawd8TraNryQeJnvH1eLpIDgbiqymM' \
-          | sudo tee --append /etc/ssh/ssh_known_hosts
+          | sudo tee --append /etc/ssh/ssh_known_hosts > /dev/null
 
     - uses: cachix/install-nix-action@v16
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ jobs:
     - uses: nixbuild/nix-quick-install-action@v13
       with:
         nix_conf: experimental-features = nix-command
-    - uses: nixbuild/nixbuild-action@v10
+    - if: ${{ secrets.SSH_KEY_FOR_NIXBUILD }} != ""
+      uses: nixbuild/nixbuild-action@v10
       with:
         nixbuild_ssh_key: ${{ secrets.SSH_KEY_FOR_NIXBUILD }}
     - run: nix-env -iA nix-build-uncached -f nix/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,26 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
+
+        # TODO: nixbuild.net currently does not have x86_64-darwin nor aarch64-darwin support but they're working on it:
+        #
+        # | I do have another question: do you support x86_64-darwin builds and
+        # | ideally aarch64-darwin as well (I just got a new M1 MacBook)?
+        #
+        # Our long-term goal is to support x86_64-darwin and aarch64-darwin, but
+        # we don't do it today. The reason is that we really like all builds to
+        # run inside our virtualized sandbox (with our own virtual file system),
+        # since it gives us full control and also lots of insights about the
+        # builds. We have not yet ported this sandbox to MacOS, but it is
+        # definitely something we want to do.
+        #
+        # We actually _have_ aarch64-darwin machines in our build cluster,
+        # running build sandboxes for aarch64-linux. We use a mix of Hetzner
+        # instances (https://www.hetzner.com/dedicated-rootserver/mac-mini-m1)
+        # and self-hosted M1 machines for this. The aarch64-linux support is EA
+        # in nixbuild.net, so we are still experimenting a bit.
+        #
+        # - macos-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -26,7 +46,6 @@ jobs:
       with:
         name: ic-hs-test
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
     # until https://github.com/cachix/cachix-action/issues/86 is fixed:
     - run: cachix watch-store ic-hs-test &
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,23 +11,44 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macos-latest
+        # TODO: - macos-latest
         # TODO: - windows-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+    - id: setup_ssh
+      run: |
+        mkdir -p -m 700 /root/.ssh
+
+        touch /root/.ssh/nixbuild_id
+        chmod 600 /root/.ssh/nixbuild_id
+        cat << EOF > /root/.ssh/nixbuild_id
+        ${{ secrets.SSH_KEY_FOR_NIXBUILD }}
+        EOF
+
+        touch /root/.ssh/config
+        chmod 600 /root/.ssh/config
+        cat << EOF > /root/.ssh/config
+        Host eu.nixbuild.net
+          PubkeyAcceptedKeyTypes ssh-ed25519
+          IdentityFile /root/.ssh/nixbuild_id
+        EOF
+
+        echo 'eu.nixbuild.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPIQCZc54poJ8vqawd8TraNryQeJnvH1eLpIDgbiqymM' >> /etc/ssh/ssh_known_hosts
+
     - uses: cachix/install-nix-action@v16
       with:
         extra_nix_config: |
           experimental-features = nix-command
-    - run: nix-env -iA nix-build-uncached -f nix/
     - uses: cachix/cachix-action@v10
       with:
         name: ic-hs-test
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    # TODO: we might not need this if we go for remote store builds in nixbuild.net
     # until https://github.com/cachix/cachix-action/issues/86 is fixed:
-    - run: cachix watch-store ic-hs-test &
+    #- run: cachix watch-store ic-hs-test &
 
     # run a few targets explicitly, to get easier signal in the CI view
     - run: nix-build-uncached -A universal-canister

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,25 +17,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - id: setup_ssh
+    - name: Configure SSH such that GitHub can authenticate with nixbuild.net
       run: |
-        mkdir -p -m 700 /root/.ssh
+        sudo mkdir -p -m 700 /root/.ssh
 
-        touch /root/.ssh/nixbuild_id
-        chmod 600 /root/.ssh/nixbuild_id
-        cat << EOF > /root/.ssh/nixbuild_id
+        sudo touch /root/.ssh/nixbuild_id
+        sudo chmod 600 /root/.ssh/nixbuild_id
+        cat << EOF | sudo tee /root/.ssh/nixbuild_id > /dev/null
         ${{ secrets.SSH_KEY_FOR_NIXBUILD }}
         EOF
 
-        touch /root/.ssh/config
-        chmod 600 /root/.ssh/config
-        cat << EOF > /root/.ssh/config
+        sudo touch /root/.ssh/config
+        sudo chmod 600 /root/.ssh/config
+        cat << EOF | sudo tee --append /root/.ssh/config > /dev/null
         Host eu.nixbuild.net
           PubkeyAcceptedKeyTypes ssh-ed25519
           IdentityFile /root/.ssh/nixbuild_id
         EOF
 
-        echo 'eu.nixbuild.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPIQCZc54poJ8vqawd8TraNryQeJnvH1eLpIDgbiqymM' >> /etc/ssh/ssh_known_hosts
+        echo 'eu.nixbuild.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPIQCZc54poJ8vqawd8TraNryQeJnvH1eLpIDgbiqymM' \
+          | sudo tee --append /etc/ssh/ssh_known_hosts
 
     - uses: cachix/install-nix-action@v16
       with:

--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ It’s necessary to wrap all lines with the `r $ …` for now; this sets the
 endpoint parameter.
 
 
+Continuous Integration
+----------------------
+
+We use GitHub Actions to trigger builds of the jobs defined in `./default.nix`. However the builds themselves are run on the [nixbuild.net](https://nixbuild.net/) service since it provides more capacity and is more efficient than GitHub runners.
+
+Please use the artifacts produced by GitHub Actions and nixbuild.net at your own risk or consider building independently from source.
+
+
 Running
 -------
 


### PR DESCRIPTION
GitHub Actions Runners only have 7GB of memory which is proving to be too small to built ic-hs. So instead of building nix derivations on a runner locally we configure the runner to build derivations remotely on [nixbuild.net](https://nixbuild.net/).

The above requires access to a private SSH key, which is used to authenticate with nixbuild.net. This key is not accessible on PRs originating from forks because that would allow leaking the key. For those PRs we don't configure nixbuild.net as a remote builder and build locally instead.