### PR TITLE
fix: performance_counter signature

### DIFF
--- a/src/IC/Canister/Imp.hs
+++ b/src/IC/Canister/Imp.hs
@@ -576,8 +576,8 @@ systemAPI esref =
         return (fromIntegral ns)
 
     -- TODO: implement once semantics of performance_counter is known.
-    performance_counter :: () -> HostM s Word64
-    performance_counter () = return 0
+    performance_counter :: Int32 -> HostM s Word64
+    performance_counter _ = return 0
 
     debug_print :: (Int32, Int32) -> HostM s ()
     debug_print (src, size) = do

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -810,7 +810,7 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
     , t "msg_method_name"              "F"             $ ignore methodName
     , t "accept_message"               never             acceptMessage -- due to double accept
     , t "time"                         star            $ ignore getTime
-    , t "performance_counter"          star            $ ignore performanceCounter
+    , t "performance_counter"          star            $ ignore $ performanceCounter (int 0)
     , t "debug_print"                  star            $ debugPrint "hello"
     , t "trap"                         never           $ trap "this better traps"
     ]

--- a/src/IC/Test/Universal.hs
+++ b/src/IC/Test/Universal.hs
@@ -224,7 +224,7 @@ stable64Write = op 48
 onHeartbeat :: Exp 'B -> Prog
 onHeartbeat = op 49
 
-performanceCounter :: Exp 'I64
+performanceCounter :: Exp 'I -> Exp 'I64
 performanceCounter = op 50
 
 getBalance128 :: Exp 'B

--- a/universal-canister/src/api.rs
+++ b/universal-canister/src/api.rs
@@ -62,7 +62,7 @@ mod ic0 {
         pub fn data_certificate_copy(dst: u32, offset: u32, size: u32) -> ();
 
         pub fn time() -> u64;
-        pub fn performance_counter() -> u64;
+        pub fn performance_counter(_type: u32) -> u64;
     }
 }
 
@@ -298,10 +298,8 @@ pub fn accept_message() {
     unsafe { ic0::accept_message() }
 }
 
-pub fn performance_counter() -> u64 {
-    unsafe {
-        ic0::performance_counter()
-    }
+pub fn performance_counter(_type: u32) -> u64 {
+    unsafe { ic0::performance_counter(_type) }
 }
 
 pub fn method_name() -> Vec<u8> {

--- a/universal-canister/src/main.rs
+++ b/universal-canister/src/main.rs
@@ -284,28 +284,25 @@ fn eval(ops: Ops) {
             // canister heartbeat script
             49 => set_heartbeat(stack.pop_blob()),
 
-            50 => stack.push_int64(api::performance_counter()),
+            50 => {
+                let _type = stack.pop_int() as u32;
+                stack.push_int64(api::performance_counter(_type))
+            }
 
             // 128-bit cycles API
-            51 => {
-                stack.push_blob(api::balance128())
-            },
-            52 => {
-                stack.push_blob(api::cycles_available128())
-            },
-            53 => {
-                stack.push_blob(api::cycles_refunded128())
-            },
+            51 => stack.push_blob(api::balance128()),
+            52 => stack.push_blob(api::cycles_available128()),
+            53 => stack.push_blob(api::cycles_refunded128()),
             54 => {
                 let low = stack.pop_int64();
                 let high = stack.pop_int64();
                 stack.push_blob(api::accept128(high, low))
-            },
+            }
             55 => {
                 let low = stack.pop_int64();
                 let high = stack.pop_int64();
                 api::call_cycles_add128(high, low)
-            },
+            }
 
             // canister heartbeat script
             56 => set_transform(stack.pop_blob()),


### PR DESCRIPTION
This change fixes the signature of "ic0.performance_counter" system API
to agree with the latest interface spec.

See
https://github.com/dfinity/interface-spec/blob/f5fc17b4e2ac0e930b6a29a3f25226b3c4b56a6f/spec/ic0.txt#L62