### PR TITLE
Revert ".github/workflows/release.yml: disable MacOS builds in release job"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
         include:
           - os: ubuntu-latest
             nix-system: x86_64-linux
+          - os: macos-latest
+            nix-system: x86_64-darwin
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We need to update the ic-ref that we bundle with the SDK to one that supports `ic0.performance_counter`

Reverts dfinity/ic-hs#82