### PR TITLE
fix: only ascii characters in strings

### DIFF
--- a/src/IC/HTTP/CBOR.hs
+++ b/src/IC/HTTP/CBOR.hs
@@ -38,7 +38,7 @@ decode s =
     begin _ = Left "Expected CBOR request to begin with tag 55799"
 
     shorten :: Int -> T.Text -> T.Text
-    shorten n s = a <> (if T.null b then "" else "…")
+    shorten n s = a <> (if T.null b then "" else "...")
         where (a,b) = T.splitAt n s
 
     go (TInt n) | n < 0 = Left "Negative integer"

--- a/src/IC/Purify.hs
+++ b/src/IC/Purify.hs
@@ -43,7 +43,7 @@ instance (SnapshotAble i, SnapshotOf i ~ a) => Purify i (Snapshot a) where
 
 newtype Replay i = Replay (forall s. ST s (i s))
 
-instance Show (Replay i) where show _ = "Replay …"
+instance Show (Replay i) where show _ = "Replay ..."
 
 instance Purify a (Replay a) where
   create = Replay

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -779,7 +779,7 @@ textual :: Blob -> String
 textual = T.unpack . prettyPrincipal . Principal
 
 shorten :: Int -> String -> String
-shorten n s = a ++ (if null b then "" else "…")
+shorten n s = a ++ (if null b then "" else "...")
   where (a,b) = splitAt n s
 
 toHash256 :: Blob -> Haskoin.Hash256

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -776,7 +776,7 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
     , t "canister_self"                star          $ ignore self
     , t "canister_cycle_balance"       star          $ ignore getBalance
     , t "canister_cycle_balance128"    star          $ ignore getBalance128
-    , t "call_new…call_perform"        "U Rt Ry H"   $
+    , t "call_new_call_perform"        "U Rt Ry H"   $
         callNew "foo" "bar" "baz" "quux" >>>
         callDataAppend "foo" >>>
         callCyclesAdd (int64 0) >>>

--- a/src/IC/Wasm/Winter/Persist.hs
+++ b/src/IC/Wasm/Winter/Persist.hs
@@ -102,7 +102,7 @@ instance Persistable a => Persistable [a] where
   type M [a] = M a
   persist = mapM persist
   resume xs ys = do
-    unless (length xs == length ys) $ error "Lengths don’t match"
+    unless (length xs == length ys) $ error "Lengths don't match"
     zipWithM_ resume xs ys
 
 instance Persistable a => Persistable (V.Vector a) where
@@ -110,7 +110,7 @@ instance Persistable a => Persistable (V.Vector a) where
   type M (V.Vector a) = M a
   persist = mapM persist
   resume xs ys = do
-    unless (V.length xs == V.length ys) $ error "Lengths don’t match"
+    unless (V.length xs == V.length ys) $ error "Lengths don't match"
     V.zipWithM_ resume xs ys
 
 instance (Eq k, Persistable a) => Persistable (M.Map k a) where
@@ -118,7 +118,7 @@ instance (Eq k, Persistable a) => Persistable (M.Map k a) where
   type M (M.Map k a) = M a
   persist = mapM persist
   resume xs ys = do
-    unless (M.keys xs == M.keys ys) $ error "Map keys don’t match"
+    unless (M.keys xs == M.keys ys) $ error "Map keys don't match"
     zipWithM_ resume (M.elems xs) (M.elems ys)
 
 instance Persistable a => Persistable (IM.IntMap a) where
@@ -127,7 +127,7 @@ instance Persistable a => Persistable (IM.IntMap a) where
   persist = mapM persist . M.fromList . IM.toList
   resume xs ys = do
     let ys' = IM.fromList (M.toList ys)
-    unless (IM.keys xs == IM.keys ys') $ error "Map keys don’t match"
+    unless (IM.keys xs == IM.keys ys') $ error "Map keys don't match"
     zipWithM_ resume (IM.elems xs) (IM.elems ys')
 
 instance Persistable a => Persistable (a, Int) where

--- a/src/ic-ref-run.hs
+++ b/src/ic-ref-run.hs
@@ -48,27 +48,27 @@ dummyUserId = EntityId $ B.pack [0xCA, 0xFF, 0xEE]
 
 printCallRequest :: CallRequest -> IO ()
 printCallRequest (CallRequest _ _ method arg) =
-    printf "→ update %s%s\n" method (shorten 60 (candidOrPretty arg))
+    printf "=> update %s%s\n" method (shorten 60 (candidOrPretty arg))
 
 printReadStateRequest :: ReadStateRequest -> IO ()
 printReadStateRequest (ReadStateRequest _ paths) =
-    printf "→ state? %s\n" (intercalate ", " $ map (intercalate "/" . map show) paths)
+    printf "=> state? %s\n" (intercalate ", " $ map (intercalate "/" . map show) paths)
 
 printQueryRequest :: QueryRequest -> IO ()
 printQueryRequest (QueryRequest _ _ method arg) =
-    printf "→ query %s%s\n" method (shorten 60 (candidOrPretty arg))
+    printf "=> query %s%s\n" method (shorten 60 (candidOrPretty arg))
 
 printCallResponse :: CallResponse -> IO ()
 printCallResponse (Rejected (c, s, _err)) =
-    printf "← rejected (%s): %s\n" (show c) s
+    printf "<= rejected (%s): %s\n" (show c) s
 printCallResponse (Replied blob) =
-    printf "← replied: %s\n" (shorten 100 (candidOrPretty blob))
+    printf "<= replied: %s\n" (shorten 100 (candidOrPretty blob))
 
 printReqStatus :: RequestStatus -> IO ()
 printReqStatus Received =
-    printf "← received\n"
+    printf "<= received\n"
 printReqStatus Processing =
-    printf "← processing\n"
+    printf "<= processing\n"
 printReqStatus (CallResponse c) = printCallResponse c
 
 printReqResponse :: ReqResponse -> IO ()
@@ -85,7 +85,7 @@ candidOrPretty b
 
 
 shorten :: Int -> String -> String
-shorten n s = a ++ (if null b then "" else "…")
+shorten n s = a ++ (if null b then "" else "...")
   where (a,b) = splitAt n s
 
 


### PR DESCRIPTION
Replace all non-ascii characters by their ASCII counterparts to make the code work in the ic repo's nix-shell.