### PR TITLE
Request IDs must be 32 bytes in length.

### DIFF
--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -405,7 +405,8 @@ authReadStateRequest t ecid ev (ReadStateRequest user_id paths) = do
               unless (S.member user_id cs) $
                 throwError "User is not authorized to read this metadata field"
             _ -> return () -- public or absent
-      ("request_status":rid: _) -> if BS.length rid /= 32 then throwError "Request IDs must be 32 bytes in length." else
+      ("request_status":rid: _) | BS.length rid /= 32 -> throwError "Request IDs must be 32 bytes in length."
+      ("request_status":rid: _) ->                            
         gets (findRequest rid) >>= \case
           Just (ar@(CallRequest cid _ meth arg),_) -> do
             checkEffectiveCanisterID ecid cid meth arg

--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -405,7 +405,7 @@ authReadStateRequest t ecid ev (ReadStateRequest user_id paths) = do
               unless (S.member user_id cs) $
                 throwError "User is not authorized to read this metadata field"
             _ -> return () -- public or absent
-      ("request_status":rid: _) ->
+      ("request_status":rid: _) -> if BS.length rid /= 32 then throwError "Request IDs must be 32 bytes in length." else
         gets (findRequest rid) >>= \case
           Just (ar@(CallRequest cid _ meth arg),_) -> do
             checkEffectiveCanisterID ecid cid meth arg

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -1590,11 +1590,17 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
         cert <- getStateCert anonymousUser cid [["canister", cid, "module_hash"]]
         certValue @Blob cert ["canister", cid, "module_hash"] >>= is (sha256 universal_wasm)
 
+    , testGroup "malformed request id"
+        [ simpleTestCase ("rid \"" ++ shorten 8 (asHex rid) ++ "\"") $ \cid -> do
+            getStateCert' defaultUser cid [["request_status", rid]] >>= code4xx
+        | rid <- [ "", "foo" ]
+        ]
+
     , testGroup "non-existence proofs for non-existing request id"
         [ simpleTestCase ("rid \"" ++ shorten 8 (asHex rid) ++ "\"") $ \cid -> do
             cert <- getStateCert defaultUser cid [["request_status", rid]]
             certValueAbsent cert ["request_status", rid, "status"]
-        | rid <- [ "", BS.replicate 32 0, BS.replicate 32 8, BS.replicate 32 255 ]
+        | rid <- [ BS.replicate 32 0, BS.replicate 32 8, BS.replicate 32 255 ]
         ]
 
     , simpleTestCase "can ask for portion of request status " $ \cid -> do


### PR DESCRIPTION
According to [Interface Spec](https://github.com/dfinity/interface-spec/pull/87), a request id must have length of 32 bytes. Hence, a read request for the status of a request whose id does not have this length is a malformed read state request that should be rejected with 4xx.