### PR TITLE
display more characters in HTTP error messages

### DIFF
--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -626,7 +626,7 @@ codePred expt pred response = assertBool
     (pred c)
   where
     c = statusCode (responseStatus response)
-    msg = T.unpack (T.decodeUtf8With T.lenientDecode (BS.toStrict (BS.take 200 (responseBody response))))
+    msg = T.unpack (T.decodeUtf8With T.lenientDecode (BS.toStrict (BS.take 1000 (responseBody response))))
 
 code2xx, code202, code4xx, code202_or_4xx  :: HasCallStack => Response BS.ByteString -> IO ()
 code2xx = codePred "2xx" $ \c -> 200 <= c && c < 300


### PR DESCRIPTION
Currently, HTTP error message are trimmed like this:
```
      src/IC/Test/Agent.hs:723:
      Status 400 is not 2xx:
      Specified ingress_expiry not within expected range:
      Minimum allowed expiry: 2022-11-08 17:30:48.509933047 UTC
      Maximum allowed expiry: 2022-11-08 17:36:18.509933047 UTC
      Provided expiry:        2022-11-
```
Increasing the threshold should allow us to see the entire HTTP error message.