### PR TITLE
query balance and balance128 within the same query

### DIFF
--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -449,7 +449,6 @@ test-suite unit-test
   build-depends: unordered-containers
   build-depends: utf8-string
   build-depends: vector
-  build-depends: wide-word
   build-depends: winter
   build-depends: uglymemo
   build-depends: zlib

--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -317,6 +317,7 @@ executable ic-ref-test
   build-depends: vector
   build-depends: wai
   build-depends: warp
+  build-depends: wide-word
   build-depends: zlib
   build-depends: either
   other-modules: IC.CBOR.Parser
@@ -448,6 +449,7 @@ test-suite unit-test
   build-depends: unordered-containers
   build-depends: utf8-string
   build-depends: vector
+  build-depends: wide-word
   build-depends: winter
   build-depends: uglymemo
   build-depends: zlib
@@ -570,6 +572,7 @@ library
   build-depends: wai-cors
   build-depends: wai-extra
   build-depends: warp
+  build-depends: wide-word
   build-depends: winter
   build-depends: uglymemo
   build-depends: zlib

--- a/nix/generated/ic-hs.nix
+++ b/nix/generated/ic-hs.nix
@@ -65,6 +65,7 @@
 , wai-cors
 , wai-extra
 , warp
+, wide-word
 , winter
 , zlib
 }:
@@ -137,6 +138,7 @@ mkDerivation {
     wai-cors
     wai-extra
     warp
+    wide-word
     winter
     zlib
   ];
@@ -199,6 +201,7 @@ mkDerivation {
     wai-cors
     wai-extra
     warp
+    wide-word
     winter
     zlib
   ];

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -138,6 +138,7 @@ import Control.Concurrent
 import Control.Exception (catch)
 import Data.Traversable
 import Data.Word
+import Data.WideWord.Word128
 import GHC.TypeLits
 import System.Random
 import System.Exit
@@ -147,7 +148,6 @@ import Codec.Candid (Principal(..), prettyPrincipal)
 import qualified Data.Binary as Get
 import qualified Data.Binary.Get as Get
 import qualified Codec.Candid as Candid
-import Data.Bits
 import Data.Row
 import qualified Data.Row.Variants as V
 import qualified Haskoin.Crypto.Signature as Haskoin
@@ -691,18 +691,18 @@ asWord64 = runGet Get.getWord64le
 as2Word64 :: HasCallStack => Blob -> IO (Word64, Word64)
 as2Word64 = runGet $ (,) <$> Get.getWord64le <*> Get.getWord64le
 
-asWord64Word128 :: HasCallStack => Blob -> IO (Word64, Natural)
+asWord64Word128 :: HasCallStack => Blob -> IO (Word64, Word128)
 asWord64Word128 = runGet $ do
     word64 <- Get.getWord64le
     low <- Get.getWord64le
     high <- Get.getWord64le
-    return (word64, fromIntegral high `shiftL` 64 .|. fromIntegral low)
+    return (word64, Word128 high low)
 
-asWord128 :: HasCallStack => Blob -> IO Natural
+asWord128 :: HasCallStack => Blob -> IO Word128
 asWord128 = runGet $ do
     low <- Get.getWord64le
     high <- Get.getWord64le
-    return $ fromIntegral high `shiftL` 64 .|. fromIntegral low
+    return $ Word128 high low
 
 bothSame :: (Eq a, Show a) => (a, a) -> Assertion
 bothSame (x,y) = x @?= y

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -42,6 +42,7 @@ module IC.Test.Agent
       agentEcid,
       anonymousUser,
       as2Word64,
+      asWord64Word128,
       asHex,
       asRight,
       asWord128,
@@ -689,6 +690,13 @@ asWord64 = runGet Get.getWord64le
 
 as2Word64 :: HasCallStack => Blob -> IO (Word64, Word64)
 as2Word64 = runGet $ (,) <$> Get.getWord64le <*> Get.getWord64le
+
+asWord64Word128 :: HasCallStack => Blob -> IO (Word64, Natural)
+asWord64Word128 = runGet $ do
+    word64 <- Get.getWord64le
+    low <- Get.getWord64le
+    high <- Get.getWord64le
+    return (word64, fromIntegral high `shiftL` 64 .|. fromIntegral low)
 
 asWord128 :: HasCallStack => Blob -> IO Natural
 asWord128 = runGet $ do

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -1893,7 +1893,7 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
         -- some more.
         eps = 3_000_000_000_000 :: Integer
 
-        isRoughly :: (HasCallStack, Show a, Num a, Integral a) => a -> a -> Assertion
+        isRoughly :: (HasCallStack, Show a, Num a, Integral a, Show b, Num b, Integral b) => a -> b -> Assertion
         isRoughly exp act = assertBool
            (show act ++ " not near " ++ show exp)
            (abs (fromIntegral exp - fromIntegral act) < eps)
@@ -1970,7 +1970,7 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
     , testCase "cycles in canister_status" $ do
         cid <- create noop
         cs <- ic_canister_status ic00 cid
-        isRoughly (fromIntegral def_cycles) (cs .! #cycles)
+        isRoughly def_cycles (cs .! #cycles)
 
     , testGroup "cycle balance"
       [ testCase "install" $ do
@@ -2047,7 +2047,7 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
           , on_reply = replyData (i64tob getRefund)
           , on_reject = trap "unexpected reject"
           }
-        >>= asWord64 >>= isRoughly 0
+        >>= asWord64 >>= isRoughly (0::Word64)
       queryBalance cid1 >>= isRoughly (def_cycles `div` 2)
       queryBalance cid2 >>= isRoughly (def_cycles `div` 4)
       queryBalance cid3 >>= isRoughly (2*def_cycles + def_cycles `div` 4)


### PR DESCRIPTION
Querying the balance of a canister with installed code twice in a row might not yield the same result because the canister is charged for resource usage:
```
    cycles API - backward compatibility
      canister_cycle_balance = canister_cycle_balance128 for numbers fitting in 64 bits: FAIL (10.40s)
        src/IC/Test/Agent.hs:666:
        expected: 1152921502679711556
         but got: 1152921502680301640
```
This PR fixes the above test by querying balance and balance128 within the same query.