### PR TITLE
rename canister state counter to canister version

### DIFF
--- a/src/IC/Canister/Imp.hs
+++ b/src/IC/Canister/Imp.hs
@@ -239,7 +239,7 @@ systemAPI esref =
   , toImport "ic0" "accept_message" accept_message
   , toImport "ic0" "time" get_time
   , toImport "ic0" "performance_counter" performance_counter
-  , toImport "ic0" "canister_state_counter" get_canister_state_counter
+  , toImport "ic0" "canister_version" get_canister_version
 
   , toImport "ic0" "debug_print" debug_print
   , toImport "ic0" "trap" explicit_trap
@@ -580,9 +580,9 @@ systemAPI esref =
     performance_counter :: Int32 -> HostM s Word64
     performance_counter _ = return 0
 
-    get_canister_state_counter :: () -> HostM s Word64
-    get_canister_state_counter () = do
-        ns <- gets (env_canister_state_counter . env)
+    get_canister_version :: () -> HostM s Word64
+    get_canister_version () = do
+        ns <- gets (env_canister_version . env)
         return (fromIntegral ns)
 
     debug_print :: (Int32, Int32) -> HostM s ()

--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -143,7 +143,7 @@ data CanState = CanState
   , time :: Timestamp
   , cycle_balance :: Natural
   , certified_data :: Blob
-  , canister_state_counter :: Natural
+  , canister_version :: Natural
   -- |Not part of the spec, but in this implementation we schedule
   -- heartbeats only for canisters who have not been idle since the
   -- last heartbeat, so we remember the last action.
@@ -256,7 +256,7 @@ createEmptyCanister cid controllers time = modify $ \ic ->
       , time = time
       , cycle_balance = 0
       , certified_data = ""
-      , canister_state_counter = 0
+      , canister_version = 0
       , last_action = Nothing
       }
 
@@ -359,12 +359,12 @@ getCanisterMod cid = can_mod . fromJust . content <$> getCanister cid
 getCanisterTime :: ICM m => CanisterId -> m Timestamp
 getCanisterTime cid = time <$> getCanister cid
 
-getCanisterStateCounter :: ICM m => CanisterId -> m Natural
-getCanisterStateCounter cid = canister_state_counter <$> getCanister cid
+getCanisterVersion :: ICM m => CanisterId -> m Natural
+getCanisterVersion cid = canister_version <$> getCanister cid
 
-bumpCanisterStateCounter :: ICM m => CanisterId -> m ()
-bumpCanisterStateCounter cid = modCanister cid $
-    \cs -> cs { canister_state_counter = canister_state_counter cs + 1 }
+bumpCanisterVersion :: ICM m => CanisterId -> m ()
+bumpCanisterVersion cid = modCanister cid $
+    \cs -> cs { canister_version = canister_version cs + 1 }
 
 module_hash :: CanState -> Maybe Blob
 module_hash = fmap (raw_wasm_hash . can_mod) . content
@@ -443,14 +443,14 @@ canisterEnv canister_id = do
       IsStopping _pending -> Stopping
       IsStopped -> Stopped
       IsDeleted -> error "deleted canister encountered"
-  env_canister_state_counter <- getCanisterStateCounter canister_id
+  env_canister_version <- getCanisterVersion canister_id
   return $ Env
     { env_self = canister_id
     , env_time
     , env_balance
     , env_status
     , env_certificate = Nothing
-    , env_canister_state_counter
+    , env_canister_version
     }
 
 -- Synchronous requests
@@ -1018,7 +1018,7 @@ icInstallCode caller r = do
     let
       reinstall = do
         env <- canisterEnv canister_id
-        let env1 = env { env_canister_state_counter = env_canister_state_counter env + 1 }
+        let env1 = env { env_canister_version = env_canister_version env + 1 }
         (wasm_state, ca) <- return (init_method new_can_mod caller env1 arg)
           `onTrap` (\msg -> reject RC_CANISTER_ERROR ("Initialization trapped: " ++ msg) (Just EC_CANISTER_TRAPPED))
         setCanisterContent canister_id $ CanisterContent
@@ -1026,7 +1026,7 @@ icInstallCode caller r = do
             , wasm_state = wasm_state
             }
         performCanisterActions canister_id ca
-        bumpCanisterStateCounter canister_id
+        bumpCanisterVersion canister_id
 
       install = do
         unless was_empty $
@@ -1044,7 +1044,7 @@ icInstallCode caller r = do
           `onTrap` (\msg -> reject RC_CANISTER_ERROR ("Pre-upgrade trapped: " ++ msg) (Just EC_CANISTER_TRAPPED))
         -- TODO: update balance in env based on ca1 here, once canister actions
         -- can change balances
-        let env2 = env { env_canister_state_counter = env_canister_state_counter env + 1 }
+        let env2 = env { env_canister_version = env_canister_version env + 1 }
         (new_wasm_state, ca2) <- return (post_upgrade_method new_can_mod caller env2 mem arg)
           `onTrap` (\msg -> reject RC_CANISTER_ERROR ("Post-upgrade trapped: " ++ msg) (Just EC_CANISTER_TRAPPED))
 
@@ -1053,7 +1053,7 @@ icInstallCode caller r = do
             , wasm_state = new_wasm_state
             }
         performCanisterActions canister_id (ca1 <> ca2)
-        bumpCanisterStateCounter canister_id
+        bumpCanisterVersion canister_id
 
     R.switch (r .! #mode) $ R.empty
       .+ #install .== (\() -> install)
@@ -1067,7 +1067,7 @@ icUninstallCode r = do
     modCanister canister_id $ \can_state -> can_state
       { content = Nothing
       , certified_data = ""
-      , canister_state_counter = canister_state_counter can_state + 1
+      , canister_version = canister_version can_state + 1
       }
     -- reject all call open contexts of this canister
     gets (M.toList . call_contexts) >>= mapM_ (\(ctxt_id, ctxt) ->
@@ -1081,7 +1081,7 @@ icUpdateCanisterSettings r = do
     let canister_id = principalToEntityId (r .! #canister_id)
     validateSettings (r .! #settings)
     applySettings canister_id (r .! #settings)
-    bumpCanisterStateCounter canister_id
+    bumpCanisterVersion canister_id
 
 icStartCanister :: (ICM m, CanReject m) => ICManagement m .! "start_canister"
 icStartCanister r = do

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -818,6 +818,7 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
     , t "accept_message"               never             acceptMessage -- due to double accept
     , t "time"                         star            $ ignore getTime
     , t "performance_counter"          star            $ ignore $ performanceCounter (int 0)
+    , t "canister_version"             star            $ ignore $ canisterVersion
     , t "debug_print"                  star            $ debugPrint "hello"
     , t "trap"                         never           $ trap "this better traps"
     ]
@@ -1199,95 +1200,95 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
       query cid (replyData getGlobal) >>= as2Word64 >>= bothSame
     ]
 
-  , testGroup "canister state counter" $
-    let canister_state_counter = i64tob canisterStateCounter in
+  , testGroup "canister version" $
+    let canister_version = i64tob canisterVersion in
     [ simpleTestCase "in query" $ \cid -> do
-      ctr <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr <- query cid (replyData canister_version) >>= asWord64
       ctr @?= 1
     , simpleTestCase "in update" $ \cid -> do
-      ctr <- call cid (replyData canister_state_counter) >>= asWord64
+      ctr <- call cid (replyData canister_version) >>= asWord64
       ctr @?= 1
     , testCase "in install" $ do
-      cid <- install $ setGlobal canister_state_counter
+      cid <- install $ setGlobal canister_version
       ctr1 <- query cid (replyData getGlobal) >>= asWord64
-      ctr2 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
     , testCase "in reinstall" $ do
       cid <- install noop
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
-      _ <- reinstall cid $ setGlobal canister_state_counter
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      _ <- reinstall cid $ setGlobal canister_version
       ctr2 <- query cid (replyData getGlobal) >>= asWord64
-      ctr3 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr3 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 2
       ctr3 @?= 2
     , testCase "in pre_upgrade" $ do
       cid <- install $
         ignore (stableGrow (int 1)) >>>
-        onPreUpgrade (callback $ stableWrite (int 0) canister_state_counter)
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
+        onPreUpgrade (callback $ stableWrite (int 0) canister_version)
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
       upgrade cid noop
       ctr2 <- query cid (replyData (stableRead (int 0) (int 8))) >>= asWord64
-      ctr3 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr3 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
       ctr3 @?= 2
     , simpleTestCase "in post_upgrade" $ \cid -> do
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
-      upgrade cid $ setGlobal canister_state_counter
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      upgrade cid $ setGlobal canister_version
       ctr2 <- query cid (replyData getGlobal) >>= asWord64
-      ctr3 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr3 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 2
       ctr3 @?= 2
     , simpleTestCase "after uninstalling canister" $ \cid -> do
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
       ic_uninstall ic00 cid
       installAt cid noop
-      ctr2 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 3
     , simpleTestCase "after setting controllers" $ \cid -> do
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
       ic_set_controllers ic00 cid [otherUser]
-      ctr2 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 2
     , simpleTestCase "after setting freezing threshold" $ \cid -> do
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
       ic_update_settings ic00 cid (#freezing_threshold .== 2^(20::Int))
-      ctr2 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 2
     , testCase "after failed install" $ do
       cid <- create
       _ <- ic_install' ic00 (enum #install) cid "" ""
       cid <- install noop
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
     , simpleTestCase "after failed reinstall" $ \cid -> do
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
       _ <- ic_install' ic00 (enum #reinstall) cid "" ""
-      ctr2 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
     , simpleTestCase "after failed upgrade" $ \cid -> do
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
       _ <- ic_install' ic00 (enum #upgrade) cid "" ""
-      ctr2 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
     , simpleTestCase "after failed uninstall" $ \cid -> do
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
       _ <- ic_uninstall'' otherUser cid
-      ctr2 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
     , simpleTestCase "after failed change of settings" $ \cid -> do
-      ctr1 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
       _ <- ic_update_settings' ic00 cid (#freezing_threshold .== 2^(70::Int))
-      ctr2 <- query cid (replyData canister_state_counter) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
     ]

--- a/src/IC/Test/Universal.hs
+++ b/src/IC/Test/Universal.hs
@@ -257,8 +257,8 @@ getHttpReplyWithBody = op 70
 getHttpTransformContext :: Exp 'B -> Exp 'B
 getHttpTransformContext = op 71
 
-canisterStateCounter :: Exp 'I64
-canisterStateCounter = op 73
+canisterVersion :: Exp 'I64
+canisterVersion = op 73
 
 -- Some convenience combinators
 

--- a/src/IC/Types.hs
+++ b/src/IC/Types.hs
@@ -156,7 +156,7 @@ data Env = Env
     , env_balance :: Cycles
     , env_status :: Status
     , env_certificate :: Maybe Blob
-    , env_canister_state_counter :: Natural
+    , env_canister_version :: Natural
     }
 
 data TrapOr a = Trap String | Return a deriving Functor

--- a/universal-canister/src/api.rs
+++ b/universal-canister/src/api.rs
@@ -68,7 +68,7 @@ mod ic0 {
         /*
         pub fn global_timer_set(timestamp: u64) -> u64;
         */
-        pub fn canister_state_counter() -> u64;
+        pub fn canister_version() -> u64;
     }
 }
 
@@ -355,8 +355,8 @@ pub fn global_timer_set(timestamp: u64) -> u64 {
 }
 */
 
-pub fn canister_state_counter() -> u64 {
-    unsafe { ic0::canister_state_counter() }
+pub fn canister_version() -> u64 {
+    unsafe { ic0::canister_version() }
 }
 
 /// Prints the given message.

--- a/universal-canister/src/lib.rs
+++ b/universal-canister/src/lib.rs
@@ -102,6 +102,6 @@ try_from_u8!(
         GetHttpReplyWithBody = 70,
         GetHttpTransformContext = 71,
         StableFill64 = 72,
-        CanisterStateCounter = 73,
+        CanisterVersion = 73,
     }
 );

--- a/universal-canister/src/main.rs
+++ b/universal-canister/src/main.rs
@@ -331,8 +331,8 @@ fn eval(ops_bytes: OpsBytes) {
 
                 api::stable64_write(offset, &data);
             }
-            Ops::CanisterStateCounter => {
-                stack.push_int64(api::canister_state_counter());
+            Ops::CanisterVersion => {
+                stack.push_int64(api::canister_version());
             }
         }
     }


### PR DESCRIPTION
The name "canister state counter" could be confusing because the counter is not incremented upon every change of the canister state. Hence, we agreed to rename it to "canister version".