### PR TITLE
fix provisional top up test

### DIFF
--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -2169,7 +2169,7 @@ icTests = withAgentConfig $ testGroup "Interface Spec acceptance tests"
         step $ "Cycle balance now at " ++ show cycles
       , testCase "nonexisting canister" $ do
         ic_top_up''' ic00' doesn'tExist (fromIntegral def_cycles)
-          >>= isErrOrReject []
+          >>= isErrOrReject [3,5]
       ]
     ]
 


### PR DESCRIPTION
Unlike `ic-ref`, the replica does not return an HTTP error if a canister does not belong to its subnet's canister ranges. Instead, the replica rejects the request with a reject code.