### PR TITLE
run system tasks periodically

### DIFF
--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -68,6 +68,7 @@ executable ic-ref
   build-depends: aeson >=1.4.7
   build-depends: asn1-encoding
   build-depends: asn1-types
+  build-depends: async
   build-depends: atomic-write
   build-depends: base32
   build-depends: base >=4.12 && <5
@@ -178,6 +179,8 @@ executable ic-ref-run
   build-depends: aeson >=1.4.7
   build-depends: asn1-encoding
   build-depends: asn1-types
+  build-depends: async
+  build-depends: atomic-write
   build-depends: base32
   build-depends: base >=4.12 && <5
   build-depends: base64-bytestring >= 1.1
@@ -191,6 +194,7 @@ executable ic-ref-run
   build-depends: crc
   build-depends: cryptonite
   build-depends: data-default-class
+  build-depends: directory
   build-depends: ed25519
   build-depends: filepath
   build-depends: hashable
@@ -208,8 +212,11 @@ executable ic-ref-run
   build-depends: prettyprinter
   build-depends: primitive
   build-depends: process
+  build-depends: random
   build-depends: row-types
+  build-depends: serialise
   build-depends: split
+  build-depends: splitmix
   build-depends: template-haskell
   build-depends: text
   build-depends: time
@@ -251,6 +258,7 @@ executable ic-ref-run
   other-modules: IC.HTTP.CBOR
   other-modules: IC.HTTP.GenR
   other-modules: IC.HTTP.GenR.Parse
+  other-modules: IC.HTTP.Request
   other-modules: IC.HTTP.RequestId
   other-modules: IC.Id.Forms
   other-modules: IC.Id.Fresh
@@ -258,6 +266,8 @@ executable ic-ref-run
   other-modules: IC.Purify
   other-modules: IC.Ref
   other-modules: IC.Ref.IO
+  other-modules: IC.Serialise
+  other-modules: IC.StateFile
   other-modules: IC.Types
   other-modules: IC.Utils
   other-modules: IC.Version

--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -522,6 +522,7 @@ library
   build-depends: aeson >=1.4.7
   build-depends: asn1-encoding
   build-depends: asn1-types
+  build-depends: async
   build-depends: atomic-write
   build-depends: base32
   build-depends: base >=4.12 && <5

--- a/nix/generated/ic-hs.nix
+++ b/nix/generated/ic-hs.nix
@@ -6,6 +6,7 @@
 , aeson
 , asn1-encoding
 , asn1-types
+, async
 , atomic-write
 , base
 , base32
@@ -80,6 +81,7 @@ mkDerivation {
     aeson
     asn1-encoding
     asn1-types
+    async
     atomic-write
     base
     base32
@@ -146,6 +148,7 @@ mkDerivation {
     aeson
     asn1-encoding
     asn1-types
+    async
     atomic-write
     base
     base32

--- a/src/IC/HTTP.hs
+++ b/src/IC/HTTP.hs
@@ -93,7 +93,11 @@ handle store req respond = case (requestMethod req, pathInfo req) of
   where
     runIC :: StateT IC IO a -> IO a
     runIC a = do
-      x <- modifyStore store a
+      x <- modifyStore store $ do
+        -- Here we make IC.Ref use “real time”
+        lift getTimestamp >>= setAllTimesTo
+        processSystemTasks
+        a
       -- begin processing in the background (it is important that
       -- this thread returns, else warp is blocked somehow)
       void $ forkIO loopIC

--- a/src/IC/HTTP.hs
+++ b/src/IC/HTTP.hs
@@ -30,7 +30,7 @@ withApp subnets backingFile action =
     withStore (initialIC subnets) backingFile $ \store -> forkIO (loopIC store) >> (action $ handle store)
   where
     loopIC :: Store IC -> IO ()
-    loopIC store = modifyStore store aux >> threadDelay 1000 >> loopIC store
+    loopIC store = modifyStore store aux >> threadDelay 1000000 >> loopIC store
       where
         aux = do
           lift getTimestamp >>= setAllTimesTo

--- a/src/ic-ref-run.hs
+++ b/src/ic-ref-run.hs
@@ -172,7 +172,7 @@ work subnets systemTaskPeriod msg_file = do
   where
     loopIC :: Store IC -> IO ()
     loopIC store = forever $ do
-        threadDelay systemTaskPeriod
+        threadDelay (systemTaskPeriod * 1000000)
         modifyStore store aux
       where
         aux = do

--- a/src/ic-ref-run.hs
+++ b/src/ic-ref-run.hs
@@ -12,6 +12,8 @@
 module Main where
 
 import Options.Applicative hiding (empty)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (withAsync)
 import Control.Monad
 import qualified Data.Map as M
 import qualified Data.ByteString.Lazy as B
@@ -33,17 +35,17 @@ import qualified Data.Row.Variants as V
 import qualified Data.Word as W
 
 
+import IC.HTTP.Request
 import IC.Version
 import IC.Types
 import IC.Ref
 import IC.DRun.Parse (Ingress(..), parseFile)
 import IC.Management
 
+import IC.StateFile
+import IC.Serialise ()
 
 type DRun = StateT IC IO
-
-dummyUserId :: CanisterId
-dummyUserId = EntityId $ B.pack [0xCA, 0xFF, 0xEE]
 
 -- Pretty printing
 
@@ -123,44 +125,55 @@ callManagement ecid user_id l x =
   submitAndRun ecid $
     CallRequest (EntityId mempty) user_id (symbolVal l) (Candid.encode x)
 
-work :: [(SubnetType, String, [(W.Word64, W.Word64)])] -> FilePath -> IO ()
-work subnets msg_file = do
+work :: [(SubnetType, String, [(W.Word64, W.Word64)])] -> Int -> FilePath -> IO ()
+work subnets systemTaskPeriod msg_file = do
   let subs = map (\(t, n, ranges) -> SubnetConfig t n ranges) subnets
   msgs <- parseFile msg_file
 
   let user_id = dummyUserId
-  ic <- initialIC subs
-  flip evalStateT ic $
-    forM_ msgs $ \case
-      Create ecid ->
-        callManagement (EntityId ecid) user_id #provisional_create_canister_with_cycles $ empty
-          .+ #settings .== Nothing
-          .+ #amount .== Nothing
-      Install cid filename arg -> do
-        wasm <- liftIO $ B.readFile filename
-        callManagement (EntityId cid) user_id #install_code $ empty
-          .+ #mode .== V.IsJust #install ()
-          .+ #canister_id .== Candid.Principal cid
-          .+ #wasm_module .== wasm
-          .+ #arg .== arg
-      Reinstall cid filename arg -> do
-        wasm <- liftIO $ B.readFile filename
-        callManagement (EntityId cid) user_id #install_code $ empty
-          .+ #mode .== V.IsJust #reinstall ()
-          .+ #canister_id .== Candid.Principal cid
-          .+ #wasm_module .== wasm
-          .+ #arg .== arg
-      Upgrade cid filename arg -> do
-        wasm <- liftIO $ B.readFile filename
-        callManagement (EntityId cid) user_id #install_code $ empty
-          .+ #mode .== V.IsJust #upgrade ()
-          .+ #canister_id .== Candid.Principal cid
-          .+ #wasm_module .== wasm
-          .+ #arg .== arg
-      Query  cid method arg ->
-        submitQuery (QueryRequest (EntityId cid) user_id method arg)
-      Update cid method arg ->
-        submitAndRun (EntityId cid) (CallRequest (EntityId cid) user_id method arg)
+  withStore (initialIC subs) Nothing $ \store ->
+      withAsync (loopIC store) $ \_async ->
+        --flip evalStateT ic $
+          forM_ msgs $ \msg -> modifyStore store $
+           case msg of
+            Create ecid ->
+              callManagement (EntityId ecid) user_id #provisional_create_canister_with_cycles $ empty
+                .+ #settings .== Nothing
+                .+ #amount .== Nothing
+            Install cid filename arg -> do
+              wasm <- liftIO $ B.readFile filename
+              callManagement (EntityId cid) user_id #install_code $ empty
+                .+ #mode .== V.IsJust #install ()
+                .+ #canister_id .== Candid.Principal cid
+                .+ #wasm_module .== wasm
+                .+ #arg .== arg
+            Reinstall cid filename arg -> do
+              wasm <- liftIO $ B.readFile filename
+              callManagement (EntityId cid) user_id #install_code $ empty
+                .+ #mode .== V.IsJust #reinstall ()
+                .+ #canister_id .== Candid.Principal cid
+                .+ #wasm_module .== wasm
+                .+ #arg .== arg
+            Upgrade cid filename arg -> do
+              wasm <- liftIO $ B.readFile filename
+              callManagement (EntityId cid) user_id #install_code $ empty
+                .+ #mode .== V.IsJust #upgrade ()
+                .+ #canister_id .== Candid.Principal cid
+                .+ #wasm_module .== wasm
+                .+ #arg .== arg
+            Query  cid method arg ->
+              submitQuery (QueryRequest (EntityId cid) user_id method arg)
+            Update cid method arg ->
+              submitAndRun (EntityId cid) (CallRequest (EntityId cid) user_id method arg)
+  where
+    loopIC :: Store IC -> IO ()
+    loopIC store = forever $ do
+        threadDelay systemTaskPeriod
+        modifyStore store aux
+      where
+        aux = do
+          lift getTimestamp >>= setAllTimesTo
+          processSystemTasks
 
 main :: IO ()
 main = join . customExecParser (prefs showHelpOnError) $
@@ -180,6 +193,8 @@ main = join . customExecParser (prefs showHelpOnError) $
     range n = (n * canister_ids_per_subnet, (n + 1) * canister_ids_per_subnet - 1)
     defaultSubnetConfig :: [(SubnetType, String, [(W.Word64, W.Word64)])]
     defaultSubnetConfig = [(System, "sk1", [range 0]), (Application, "sk2", [range 1])]
+    defaultSystemTaskPeriod :: Int
+    defaultSystemTaskPeriod = 1
     parser :: Parser (IO ())
     parser = work
       <$  strOption
@@ -197,6 +212,16 @@ main = join . customExecParser (prefs showHelpOnError) $
             )
           <|> pure defaultSubnetConfig
           )
+      <*>
+        (
+          (
+            option auto
+            (  long "system-task-period"
+            <> help ("choose execution period (in integer seconds) for system tasks, i.e., heartbeats and global timers (default: " ++ show defaultSystemTaskPeriod ++ ")")
+            )
+          )
+        <|> pure defaultSystemTaskPeriod
+        )
       <*> strArgument
           (  metavar "script"
           <> help "messages to execute"


### PR DESCRIPTION
Currently, system tasks (heartbeat and global timer) are only triggered upon receiving an HTTP request. This MR adds a new execution thread that periodically triggers these tasks every second.