### PR TITLE
do not return an HTTP error for calls to stopping/stopped canisters

### DIFF
--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -539,9 +539,6 @@ inspectIngress (CallRequest canister_id user_id method arg)
   | otherwise = do
     onReject (throwError . T.pack . rejectMessage) $
         canisterMustExist canister_id
-    getRunStatus canister_id >>= \case
-       IsRunning -> return ()
-       _ -> throwError "canister is stopped"
     empty <- isCanisterEmpty canister_id
     when empty $ throwError "canister is empty"
     wasm_state <- getCanisterState canister_id

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -644,7 +644,7 @@ icTests subnet = withAgentConfig $ testGroup "Interface Spec acceptance tests"
       ic_stop_canister ic00 cid
 
       step "Cannot call (update)?"
-      call'' cid reply >>= isErrOrReject [5]
+      call' cid reply >>= isReject [5]
 
       step "Cannot call (query)?"
       query' cid reply >>= isReject [5]
@@ -710,7 +710,7 @@ icTests subnet = withAgentConfig $ testGroup "Interface Spec acceptance tests"
       awaitKnown grs3 >>= isPendingOrProcessing
 
       step "Cannot call (update)?"
-      call'' cid reply >>= isErrOrReject [5]
+      call' cid reply >>= isReject [5]
 
       step "Cannot call (query)?"
       query' cid reply >>= isReject [5]
@@ -729,7 +729,7 @@ icTests subnet = withAgentConfig $ testGroup "Interface Spec acceptance tests"
 
 
       step "Cannot call (update)?"
-      call'' cid reply >>= isErrOrReject [5]
+      call' cid reply >>= isReject [5]
 
       step "Cannot call (query)?"
       query' cid reply >>= isReject [5]


### PR DESCRIPTION
Calls to stopping/stopped canisters should not be rejected with an HTTP error (see [API Request submission](https://ic-interface-spec.netlify.app/#_api_request_submission) which can succeed even if the canister is not running). Instead, the request should go through the states received, processing, and finally rejected.