### PR TITLE
fix reject code of installing on (non-)empty canister

### DIFF
--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -1104,12 +1104,12 @@ icInstallCode caller r = do
 
       install = do
         unless was_empty $
-          reject RC_DESTINATION_INVALID "canister is not empty during installation" (Just EC_CANISTER_NOT_EMPTY)
+          reject RC_CANISTER_ERROR "canister is not empty during installation" (Just EC_CANISTER_NOT_EMPTY)
         reinstall
 
       upgrade = do
         when was_empty $
-          reject RC_DESTINATION_INVALID "canister is empty during upgrade" (Just EC_CANISTER_EMPTY)
+          reject RC_CANISTER_ERROR "canister is empty during upgrade" (Just EC_CANISTER_EMPTY)
         old_wasm_state <- getCanisterState canister_id
         old_can_mod <- getCanisterMod canister_id
         env <- canisterEnv canister_id


### PR DESCRIPTION
This PR fixes a regression due to dropping `rejectAsCanister`: `dfx` expects reject code 5 when installing code on non-empty canister or upgrading an empty canister. This is in line with the [starvation](https://ic-interface-spec.netlify.app/#rule-starvation) transition that would be taken in this case and the description of the reject code 3: "DESTINATION_INVALID (3): Invalid destination (e.g. canister/account does not exist)" that is not applicable in this case.