### PR TITLE
fix macOS artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     - run: nix-build-uncached
 
   release:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name == 'push' }}
     needs: test
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,8 @@ jobs:
         echo "::set-output name=out::$out_path"
 
     - run: |
-        tar -C "${{ steps.buildit.outputs.out }}/bin" -czvf ic-ref.tar.gz ic-ref
+        tar -C "${{ steps.buildit.outputs.out }}/bin" -czvf ic-ref.tar.gz ic-ref *.dylib
         tar -C "${{ steps.buildit.outputs.out }}" -czvf ic-ref-test.tar.gz bin test-data
-
-        "${{ steps.buildit.outputs.out }}/bin/ic-ref" --version
-        ls -l "${{ steps.buildit.outputs.out }}/bin"
 
         ref_short="$(echo "$GITHUB_SHA" | cut -c1-8)"
         version="${{ steps.get_version.outputs.version }}-$ref_short"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,12 @@ jobs:
         echo "::set-output name=out::$out_path"
 
     - run: |
-        tar -C "${{ steps.buildit.outputs.out }}/bin" -czvf ic-ref.tar.gz ic-ref *.dylib
+        if [[ -d "${{ steps.buildit.outputs.out }}/bin/libs" ]]
+        then
+          tar -C "${{ steps.buildit.outputs.out }}/bin" -czvf ic-ref.tar.gz ic-ref libs
+        else
+          tar -C "${{ steps.buildit.outputs.out }}/bin" -czvf ic-ref.tar.gz ic-ref
+        fi
         tar -C "${{ steps.buildit.outputs.out }}" -czvf ic-ref-test.tar.gz bin test-data
 
         ref_short="$(echo "$GITHUB_SHA" | cut -c1-8)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,13 +91,13 @@ jobs:
         echo "::set-output name=out::$out_path"
 
     - run: |
-        if [[ -d "${{ steps.buildit.outputs.out }}/bin/libs" ]]
+        if [[ -d "${{ steps.buildit.outputs.out }}/build/libs" ]]
         then
-          tar -C "${{ steps.buildit.outputs.out }}/bin" -czvf ic-ref.tar.gz ic-ref libs
+          tar -C "${{ steps.buildit.outputs.out }}/build" -czvf ic-ref.tar.gz ic-ref libs
         else
-          tar -C "${{ steps.buildit.outputs.out }}/bin" -czvf ic-ref.tar.gz ic-ref
+          tar -C "${{ steps.buildit.outputs.out }}/build" -czvf ic-ref.tar.gz ic-ref
         fi
-        tar -C "${{ steps.buildit.outputs.out }}" -czvf ic-ref-test.tar.gz bin test-data
+        tar -C "${{ steps.buildit.outputs.out }}" -czvf ic-ref-test.tar.gz build test-data
 
         ref_short="$(echo "$GITHUB_SHA" | cut -c1-8)"
         version="${{ steps.get_version.outputs.version }}-$ref_short"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
     - run: nix-build-uncached
 
   release:
-    if: ${{ github.event_name == 'push' }}
     needs: test
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     - run: nix-build-uncached
 
   release:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     needs: test
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
         tar -C "${{ steps.buildit.outputs.out }}" -czvf ic-ref-test.tar.gz bin test-data
 
         "${{ steps.buildit.outputs.out }}/bin/ic-ref" --version
+        ls -l "${{ steps.buildit.outputs.out }}/bin"
 
         ref_short="$(echo "$GITHUB_SHA" | cut -c1-8)"
         version="${{ steps.get_version.outputs.version }}-$ref_short"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
         tar -C "${{ steps.buildit.outputs.out }}/bin" -czvf ic-ref.tar.gz ic-ref
         tar -C "${{ steps.buildit.outputs.out }}" -czvf ic-ref-test.tar.gz bin test-data
 
+        "${{ steps.buildit.outputs.out }}/bin/ic-ref" --version
+
         ref_short="$(echo "$GITHUB_SHA" | cut -c1-8)"
         version="${{ steps.get_version.outputs.version }}-$ref_short"
 

--- a/default.nix
+++ b/default.nix
@@ -62,18 +62,18 @@ let
         buildInputs = [ nixpkgs.macdylibbundler nixpkgs.removeReferencesTo ];
         allowedRequisites = [];
       } ''
-        mkdir -p $out/bin/libs
-        cp ${ic-ref}/bin/ic-ref $out/bin
-        cp ${ic-ref}/bin/ic-ref-test $out/bin
+        mkdir -p $out/build/libs
+        cp ${ic-ref}/bin/ic-ref $out/build
+        cp ${ic-ref}/bin/ic-ref-test $out/build
         mkdir -p $out/test-data
         cp ${ic-ref}/test-data/universal-canister.wasm $out/test-data/universal-canister.wasm
-        chmod u+w $out/bin/ic-ref
-        chmod u+w $out/bin/ic-ref-test
+        chmod u+w $out/build/ic-ref
+        chmod u+w $out/build/ic-ref-test
         dylibbundler \
           -b \
-          -x $out/bin/ic-ref \
-          -x $out/bin/ic-ref-test \
-          -d $out/bin/libs \
+          -x $out/build/ic-ref \
+          -x $out/build/ic-ref-test \
+          -d $out/build/libs \
           -p '@executable_path/libs' \
           -i /usr/lib/system \
           -i ${nixpkgs.libiconv}/lib \
@@ -86,10 +86,10 @@ let
           -t ${nixpkgs.darwin.CF} \
           -t ${nixpkgs.libiconv} \
           -t ${staticHaskellPackages.tasty-html.data} \
-          $out/bin/*
+          $out/build/*
 
         # sanity check
-        $out/bin/ic-ref --version
+        $out/build/ic-ref --version
       ''
 
     # on Linux, build statically using musl
@@ -105,9 +105,9 @@ let
         allowedReferences = [];
         nativeBuildInputs = [ nixpkgs.removeReferencesTo ];
       } ''
-        mkdir -p $out/bin
-        cp ${ic-hs-static}/bin/ic-ref $out/bin
-        cp ${ic-hs-static}/bin/ic-ref-test $out/bin
+        mkdir -p $out/build
+        cp ${ic-hs-static}/bin/ic-ref $out/build
+        cp ${ic-hs-static}/bin/ic-ref-test $out/build
         mkdir -p $out/test-data
         cp ${ic-hs}/test-data/universal-canister.wasm $out/test-data/universal-canister.wasm
 
@@ -120,7 +120,7 @@ let
         #   warp_libexecdir"/nix/store/...-warp-static-x86_64-unknown-linux-musl-3.3.17/libexec/x86_64-linux-ghc-8.10.7/warp-3.3.17"
         #   warp_sysconfdir"/nix/store/...-warp-static-x86_64-unknown-linux-musl-3.3.17/etc"
         #
-        # These paths end up in the statically compiled $out/bin/ic-ref which
+        # These paths end up in the statically compiled $out/build/ic-ref which
         # will fail the `allowedReferences = []` check.
         #
         # Fortunatley warp doesn't use these `warp_*` paths:
@@ -134,11 +134,11 @@ let
         #   Network/Wai/Handler/Warp/Settings.hs:    , settingsServerName = C8.pack $ "Warp/" ++ showVersion Paths_warp.version
         #
         # So we can safely remove the references to warp:
-        remove-references-to -t ${staticHaskellPackages.warp} $out/bin/ic-ref
+        remove-references-to -t ${staticHaskellPackages.warp} $out/build/ic-ref
         remove-references-to \
           -t ${staticHaskellPackages.tasty-html} \
           -t ${staticHaskellPackages.tasty-html.data} \
-          $out/bin/ic-ref-test
+          $out/build/ic-ref-test
       '';
 
 

--- a/default.nix
+++ b/default.nix
@@ -75,9 +75,7 @@ let
           -x $out/bin/ic-ref-test \
           -d $out/bin \
           -p '@executable_path' \
-          -i /usr/lib/system \
-          -i ${nixpkgs.libiconv}/lib \
-          -i ${nixpkgs.darwin.Libsystem}/lib
+          -i /usr/lib/system
 
         # there are still plenty of nix store references
         # but they should not matter

--- a/default.nix
+++ b/default.nix
@@ -75,7 +75,9 @@ let
           -x $out/bin/ic-ref-test \
           -d $out/bin \
           -p '@executable_path' \
-          -i /usr/lib/system
+          -i /usr/lib/system \
+          -i ${nixpkgs.libiconv}/lib \
+          -i ${nixpkgs.darwin.Libsystem}/lib
 
         # there are still plenty of nix store references
         # but they should not matter

--- a/default.nix
+++ b/default.nix
@@ -62,7 +62,7 @@ let
         buildInputs = [ nixpkgs.macdylibbundler nixpkgs.removeReferencesTo ];
         allowedRequisites = [];
       } ''
-        mkdir -p $out/bin
+        mkdir -p $out/bin/libs
         cp ${ic-ref}/bin/ic-ref $out/bin
         cp ${ic-ref}/bin/ic-ref-test $out/bin
         mkdir -p $out/test-data
@@ -73,8 +73,8 @@ let
           -b \
           -x $out/bin/ic-ref \
           -x $out/bin/ic-ref-test \
-          -d $out/bin \
-          -p '@executable_path' \
+          -d $out/bin/libs \
+          -p '@executable_path/libs' \
           -i /usr/lib/system \
           -i ${nixpkgs.libiconv}/lib \
           -i ${nixpkgs.darwin.Libsystem}/lib


### PR DESCRIPTION
This MR fixes the error
```
dyld[2382]: Library not loaded: '@executable_path/libz.1.2.12.dylib'
  Referenced from: '/Users/runner/.cache/dfinity/versions/0.12.1+rev36.7883e5aa/ic-ref'
  Reason: tried: '/Users/runner/.cache/dfinity/versions/0.12.1+rev36.7883e5aa/libz.1.2.12.dylib' (no such file), '/usr/local/lib/libz.1.2.12.dylib' (no such file), '/usr/lib/libz.1.2.12.dylib' (no such file)
```
observed on macOS when using our artifact.