### PR TITLE
scale cycle cost of http_request calls based on subnet size

### DIFF
--- a/src/IC/Constants.hs
+++ b/src/IC/Constants.hs
@@ -14,6 +14,10 @@ import IC.Types
 cDEFAULT_PROVISIONAL_CYCLES_BALANCE :: Natural
 cDEFAULT_PROVISIONAL_CYCLES_BALANCE = 100_000_000_000_000
 
+-- Subnets
+reference_subnet_size :: W.Word64
+reference_subnet_size = 13
+
 -- Canister http_request limits
 max_request_bytes_limit :: W.Word64
 max_request_bytes_limit = 2_000_000

--- a/src/IC/Constants.hs
+++ b/src/IC/Constants.hs
@@ -15,6 +15,9 @@ cDEFAULT_PROVISIONAL_CYCLES_BALANCE :: Natural
 cDEFAULT_PROVISIONAL_CYCLES_BALANCE = 100_000_000_000_000
 
 -- Subnets
+
+-- reference_subnet_size is used for scaling cycle cost
+-- and must never be set to zero!
 reference_subnet_size :: W.Word64
 reference_subnet_size = 13
 

--- a/src/IC/Test/Agent/Calls.hs
+++ b/src/IC/Test/Agent/Calls.hs
@@ -160,7 +160,7 @@ ic_raw_rand ic00 =
 
 ic_http_get_request ::
     forall a b. (a -> IO b) ~ (ICManagement IO .! "http_request") =>
-    HasAgentConfig => IC00WithCycles -> SubnetType -> String -> Maybe W.Word64 -> Maybe (String, Blob) -> Blob -> IO b
+    HasAgentConfig => IC00WithCycles -> (SubnetType, W.Word64) -> String -> Maybe W.Word64 -> Maybe (String, Blob) -> Blob -> IO b
 ic_http_get_request ic00 sub path max_response_bytes transform canister_id =
   callIC (ic00 $ http_request_fee request sub) "" #http_request request
   where
@@ -174,7 +174,7 @@ ic_http_get_request ic00 sub path max_response_bytes transform canister_id =
 
 ic_http_post_request :: HasAgentConfig =>
     (a -> IO b) ~ (ICManagement IO .! "http_request") =>
-    IC00WithCycles -> SubnetType -> String -> Maybe W.Word64 -> Maybe BS.ByteString -> Vec.Vector HttpHeader -> Maybe (String, Blob) -> Blob -> IO b
+    IC00WithCycles -> (SubnetType, W.Word64) -> String -> Maybe W.Word64 -> Maybe BS.ByteString -> Vec.Vector HttpHeader -> Maybe (String, Blob) -> Blob -> IO b
 ic_http_post_request ic00 sub path max_response_bytes body headers transform canister_id =
   callIC (ic00 $ http_request_fee request sub) "" #http_request request
   where
@@ -188,7 +188,7 @@ ic_http_post_request ic00 sub path max_response_bytes body headers transform can
 
 ic_http_head_request :: HasAgentConfig =>
     (a -> IO b) ~ (ICManagement IO .! "http_request") =>
-    IC00WithCycles -> SubnetType -> String -> Maybe W.Word64 -> Maybe BS.ByteString -> Vec.Vector HttpHeader -> Maybe (String, Blob) -> Blob -> IO b
+    IC00WithCycles -> (SubnetType, W.Word64) -> String -> Maybe W.Word64 -> Maybe BS.ByteString -> Vec.Vector HttpHeader -> Maybe (String, Blob) -> Blob -> IO b
 ic_http_head_request ic00 sub path max_response_bytes body headers transform canister_id =
   callIC (ic00 $ http_request_fee request sub) "" #http_request request
   where
@@ -202,7 +202,7 @@ ic_http_head_request ic00 sub path max_response_bytes body headers transform can
 
 ic_long_url_http_request :: HasAgentConfig =>
   forall a b. (a -> IO b) ~ (ICManagement IO .! "http_request") =>
-  IC00WithCycles -> SubnetType -> String -> W.Word64 -> Maybe (String, Blob) -> Blob -> IO b
+  IC00WithCycles -> (SubnetType, W.Word64) -> String -> W.Word64 -> Maybe (String, Blob) -> Blob -> IO b
 ic_long_url_http_request ic00 sub proto len transform canister_id =
   callIC (ic00 $ http_request_fee request sub) "" #http_request request
   where
@@ -299,7 +299,7 @@ ic_ecdsa_public_key' ic00 canister_id path =
        .+ #name .== (T.pack "0")
     )
 
-ic_http_get_request' :: HasAgentConfig => IC00WithCycles -> SubnetType -> String -> String -> Maybe W.Word64 -> Maybe (String, Blob) -> Blob -> IO ReqResponse
+ic_http_get_request' :: HasAgentConfig => IC00WithCycles -> (SubnetType, W.Word64) -> String -> String -> Maybe W.Word64 -> Maybe (String, Blob) -> Blob -> IO ReqResponse
 ic_http_get_request' ic00 sub proto path max_response_bytes transform canister_id =
   callIC' (ic00 $ http_request_fee request sub) "" #http_request request
   where
@@ -311,7 +311,7 @@ ic_http_get_request' ic00 sub proto path max_response_bytes transform canister_i
       .+ #body .== Nothing
       .+ #transform .== (toTransformFn transform canister_id)
 
-ic_http_post_request' :: HasAgentConfig => IC00WithCycles -> SubnetType -> String -> Maybe W.Word64 -> Maybe BS.ByteString -> Vec.Vector HttpHeader -> Maybe (String, Blob) -> Blob -> IO ReqResponse
+ic_http_post_request' :: HasAgentConfig => IC00WithCycles -> (SubnetType, W.Word64) -> String -> Maybe W.Word64 -> Maybe BS.ByteString -> Vec.Vector HttpHeader -> Maybe (String, Blob) -> Blob -> IO ReqResponse
 ic_http_post_request' ic00 sub path max_response_bytes body headers transform canister_id =
   callIC' (ic00 $ http_request_fee request sub) "" #http_request request
   where
@@ -323,7 +323,7 @@ ic_http_post_request' ic00 sub path max_response_bytes body headers transform ca
       .+ #body .== body
       .+ #transform .== (toTransformFn transform canister_id)
 
-ic_http_head_request' :: HasAgentConfig => IC00WithCycles -> SubnetType -> String -> Maybe W.Word64 -> Maybe BS.ByteString -> Vec.Vector HttpHeader -> Maybe (String, Blob) -> Blob -> IO ReqResponse
+ic_http_head_request' :: HasAgentConfig => IC00WithCycles -> (SubnetType, W.Word64) -> String -> Maybe W.Word64 -> Maybe BS.ByteString -> Vec.Vector HttpHeader -> Maybe (String, Blob) -> Blob -> IO ReqResponse
 ic_http_head_request' ic00 sub path max_response_bytes body headers transform canister_id =
   callIC' (ic00 $ http_request_fee request sub) "" #http_request request
   where
@@ -335,7 +335,7 @@ ic_http_head_request' ic00 sub path max_response_bytes body headers transform ca
       .+ #body .== body
       .+ #transform .== (toTransformFn transform canister_id)
 
-ic_long_url_http_request' :: HasAgentConfig => IC00WithCycles -> SubnetType -> String -> W.Word64 -> Maybe (String, Blob) -> Blob -> IO ReqResponse
+ic_long_url_http_request' :: HasAgentConfig => IC00WithCycles -> (SubnetType, W.Word64) -> String -> W.Word64 -> Maybe (String, Blob) -> Blob -> IO ReqResponse
 ic_long_url_http_request' ic00 sub proto len transform canister_id =
   callIC' (ic00 $ http_request_fee request sub) "" #http_request request
   where

--- a/src/IC/Test/Options.hs
+++ b/src/IC/Test/Options.hs
@@ -78,8 +78,8 @@ instance Show TestSubnet where
 
 instance IsOption TestSubnet where
   defaultValue = TestSubnet (Application, 1)
-  parseValue = read
-  optionName = return "test-subnet-configuration"
+  parseValue = Just <$> read
+  optionName = return "test-subnet-config"
   optionHelp = return $ "Test subnet configuration consisting of subnet type and replication factor (default: " ++ show (TestSubnet (Application, 1)) ++ ")"
 
 testSubnetOption :: OptionDescription

--- a/src/IC/Test/Options.hs
+++ b/src/IC/Test/Options.hs
@@ -2,6 +2,7 @@ module IC.Test.Options where
 
 import Data.Proxy
 import Data.List
+import qualified Data.Word as W
 import Test.Tasty.Options
 import Options.Applicative hiding (str)
 import IC.Id.Fresh(wordToId)
@@ -65,29 +66,21 @@ polltimeoutOption = Option (Proxy :: Proxy PollTimeout)
 
 -- Configuration: Subnet type
 
-newtype TestSubnetType = TestSubnetType SubnetType
+newtype TestSubnet = TestSubnet (SubnetType, W.Word64)
 
-instance Read TestSubnetType where
-  readsPrec _ x
-    | x == "application" = return (TestSubnetType Application, "")
-    | x == "verified_application" = return (TestSubnetType VerifiedApplication, "")
-    | x == "system" = return (TestSubnetType System, "")
-    | otherwise = fail "could not read SubnetType"
+instance Read TestSubnet where
+  readsPrec p x = do
+    (y, z) <- (readsPrec p x :: [((SubnetType, W.Word64), String)])
+    return (TestSubnet y, z)
 
-instance Show TestSubnetType where
-  show (TestSubnetType Application) = "application"
-  show (TestSubnetType VerifiedApplication) = "verified_application"
-  show (TestSubnetType System) = "system"
+instance Show TestSubnet where
+  show (TestSubnet sub) = show sub
 
-instance IsOption TestSubnetType where
-  defaultValue = TestSubnetType Application
-  parseValue p
-    | p == "application" = Just $ TestSubnetType Application
-    | p == "verified_application" = Just $ TestSubnetType VerifiedApplication
-    | p == "system" = Just $ TestSubnetType System
-    | otherwise = Nothing
-  optionName = return "subnet-type"
-  optionHelp = return "Subnet type [possible values: application, verified_application, system] (default: application)"
+instance IsOption TestSubnet where
+  defaultValue = TestSubnet (Application, 1)
+  parseValue = read
+  optionName = return "test-subnet-configuration"
+  optionHelp = return $ "Test subnet configuration consisting of subnet type and replication factor (default: " ++ show (TestSubnet (Application, 1)) ++ ")"
 
-subnettypeOption :: OptionDescription
-subnettypeOption = Option (Proxy :: Proxy TestSubnetType)
+testSubnetOption :: OptionDescription
+testSubnetOption = Option (Proxy :: Proxy TestSubnet)

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -20,6 +20,7 @@ import qualified Data.HashMap.Lazy as HM
 import qualified Data.Map.Lazy as M
 import qualified Data.Set as S
 import qualified Data.Vector as Vec
+import qualified Data.Word as W
 import qualified Data.ByteString.Lazy.UTF8 as BLU
 import Data.Text.Encoding.Base64(encodeBase64)
 import Data.ByteString.Builder
@@ -150,7 +151,7 @@ check_http_body = aux . fromUtf8
     aux Nothing = False
     aux (Just s) = all ((==) 'x') $ T.unpack s
 
-canister_http_calls :: HasAgentConfig => SubnetType -> [TestTree]
+canister_http_calls :: HasAgentConfig => (SubnetType, W.Word64) -> [TestTree]
 canister_http_calls sub =
   [
     -- "Currently, the GET, HEAD, and POST methods are supported for HTTP requests."
@@ -528,8 +529,8 @@ canister_http_calls sub =
 
 -- * The test suite (see below for helper functions)
 
-icTests :: SubnetType -> AgentConfig -> TestTree
-icTests subnet = withAgentConfig $ testGroup "Interface Spec acceptance tests"
+icTests :: (SubnetType, W.Word64) -> AgentConfig -> TestTree
+icTests sub = withAgentConfig $ testGroup "Interface Spec acceptance tests"
   [ simpleTestCase "create and install" $ \_ ->
       return ()
 
@@ -863,7 +864,7 @@ icTests subnet = withAgentConfig $ testGroup "Interface Spec acceptance tests"
     assertBool "random blobs are different" $ r1 /= r2
 
   , IC.Test.Spec.TECDSA.tests
-  , testGroup "canister http calls" $ canister_http_calls subnet
+  , testGroup "canister http calls" $ canister_http_calls sub
 
   , testGroup "simple calls"
     [ simpleTestCase "Call" $ \cid ->

--- a/src/IC/Types.hs
+++ b/src/IC/Types.hs
@@ -142,6 +142,7 @@ instance Show SubnetType where
 
 data SubnetConfig = SubnetConfig
     { subnet_type :: SubnetType
+    , subnet_size :: W.Word64
     , nonce :: String
     , canister_ranges :: [(W.Word64, W.Word64)]
     }

--- a/src/ic-ref-run.hs
+++ b/src/ic-ref-run.hs
@@ -133,9 +133,9 @@ callManagement store ecid user_id l x =
   submitAndRun store ecid $
     CallRequest (EntityId mempty) user_id (symbolVal l) (Candid.encode x)
 
-work :: [(SubnetType, String, [(W.Word64, W.Word64)])] -> Int -> FilePath -> IO ()
+work :: [(SubnetType, W.Word64, String, [(W.Word64, W.Word64)])] -> Int -> FilePath -> IO ()
 work subnets systemTaskPeriod msg_file = do
-  let subs = map (\(t, n, ranges) -> SubnetConfig t n ranges) subnets
+  let subs = map (\(t, n, nonce, ranges) -> SubnetConfig t n nonce ranges) subnets
   msgs <- parseFile msg_file
 
   let user_id = dummyUserId
@@ -198,8 +198,8 @@ main = join . customExecParser (prefs showHelpOnError) $
     canister_ids_per_subnet = 1_048_576
     range :: W.Word64 -> (W.Word64, W.Word64)
     range n = (n * canister_ids_per_subnet, (n + 1) * canister_ids_per_subnet - 1)
-    defaultSubnetConfig :: [(SubnetType, String, [(W.Word64, W.Word64)])]
-    defaultSubnetConfig = [(System, "sk1", [range 0]), (Application, "sk2", [range 1])]
+    defaultSubnetConfig :: [(SubnetType, W.Word64, String, [(W.Word64, W.Word64)])]
+    defaultSubnetConfig = [(System, 1, "sk1", [range 0]), (Application, 1, "sk2", [range 1])]
     defaultSystemTaskPeriod :: Int
     defaultSystemTaskPeriod = 1
     parser :: Parser (IO ())

--- a/src/ic-ref-test.hs
+++ b/src/ic-ref-test.hs
@@ -23,8 +23,8 @@ main = do
     BLS.init
     os <- parseOptions ingredients (testGroup "dummy" [])
     ac <- preFlight os
-    let TestSubnetType subnet = lookupOption os
-    defaultMainWithIngredients ingredients (icTests subnet ac)
+    let TestSubnet sub = lookupOption os
+    defaultMainWithIngredients ingredients (icTests sub ac)
   where
     ingredients =
       [ rerunningTests
@@ -33,7 +33,7 @@ main = do
         , includingOptions [ecidOption]
         , includingOptions [httpbinOption]
         , includingOptions [polltimeoutOption]
-        , includingOptions [subnettypeOption]
+        , includingOptions [testSubnetOption]
         , antXMLRunner `composeReporters` htmlRunner `composeReporters` consoleTestReporter
         ]
       ]

--- a/src/ic-ref.hs
+++ b/src/ic-ref.hs
@@ -21,9 +21,9 @@ defaultPort :: Port
 defaultPort = 8001
 
 
-work :: [(SubnetType, String, [(W.Word64, W.Word64)])] -> Maybe String -> Int -> Maybe Int -> Maybe FilePath -> Maybe FilePath -> Bool ->  IO ()
+work :: [(SubnetType, W.Word64, String, [(W.Word64, W.Word64)])] -> Maybe String -> Int -> Maybe Int -> Maybe FilePath -> Maybe FilePath -> Bool ->  IO ()
 work subnets maybe_cert_path systemTaskPeriod portToUse writePortTo backingFile log = do
-    let subs = map (\(t, n, ranges) -> SubnetConfig t n ranges) subnets
+    let subs = map (\(t, n, nonce, ranges) -> SubnetConfig t n nonce ranges) subnets
     putStrLn "Starting ic-ref..."
     BLS.init
     certs <- case maybe_cert_path of Nothing -> return []
@@ -73,8 +73,8 @@ main = join . customExecParser (prefs showHelpOnError) $
     canister_ids_per_subnet = 1_048_576
     range :: W.Word64 -> (W.Word64, W.Word64)
     range n = (n * canister_ids_per_subnet, (n + 1) * canister_ids_per_subnet - 1)
-    defaultSubnetConfig :: [(SubnetType, String, [(W.Word64, W.Word64)])]
-    defaultSubnetConfig = [(System, "sk1", [range 0]), (Application, "sk2", [range 1])]
+    defaultSubnetConfig :: [(SubnetType, W.Word64, String, [(W.Word64, W.Word64)])]
+    defaultSubnetConfig = [(System, 1, "sk1", [range 0]), (Application, 1, "sk2", [range 1])]
     defaultSystemTaskPeriod :: Int
     defaultSystemTaskPeriod = 1
     parser :: Parser (IO ())
@@ -84,7 +84,7 @@ main = join . customExecParser (prefs showHelpOnError) $
           (
             option auto
             (  long "subnet-config"
-            <> help ("choose initial subnet configurations (default: " ++ show defaultSubnetConfig ++ ")")
+            <> help ("choose initial subnet configuration consisting of subnet type, replication factor, nonce, and canister ranges for every subnet (default: " ++ show defaultSubnetConfig ++ ")")
             )
           )
         <|> pure defaultSubnetConfig

--- a/src/unit-tests.hs
+++ b/src/unit-tests.hs
@@ -34,7 +34,7 @@ main = do
     defaultMain $ tests conf
 
 defaultSubnetConfig :: [SubnetConfig]
-defaultSubnetConfig = [SubnetConfig Application "sk" [(0, 0)]]
+defaultSubnetConfig = [SubnetConfig Application 1 "sk" [(0, 0)]]
 
 defaultEcid :: CanisterId
 defaultEcid = wordToId 0


### PR DESCRIPTION
The replica implementation scales the cost of calls as follows:
```
    // Scale cycles cost according to a subnet size.
    fn scale_cost(&self, cycles: Cycles, subnet_size: usize) -> Cycles {
        match self.use_cost_scaling_flag {
            false => cycles,
            true => (cycles * subnet_size) / self.config.reference_subnet_size,
        }
    }
```
where `self.config.reference_subnet_size` is set to
```
/// Default subnet size which is used to scale cycles cost according to a subnet replication factor.
///
/// All initial costs were calculated with the assumption that a subnet had 13 replicas.
/// IMPORTANT: never set this value to zero.
const DEFAULT_REFERENCE_SUBNET_SIZE: usize = 13;
```
Recently, `self.use_cost_scaling_flag` was enabled and thus this PR implements cycle cost scaling based on subnet size also in the reference implementation.

The scaling is only implemented for canister `http_request` management canister calls because no other operations are being charged for in the reference implementation (yet).