### PR TITLE
omit ic-ref binary in ic-ref-test artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,11 @@ jobs:
         if [[ -d "${{ steps.buildit.outputs.out }}/build/libs" ]]
         then
           tar -C "${{ steps.buildit.outputs.out }}/build" -czvf ic-ref.tar.gz ic-ref libs
+          tar -C "${{ steps.buildit.outputs.out }}" -czvf ic-ref-test.tar.gz build/ic-ref-test build/libs test-data
         else
           tar -C "${{ steps.buildit.outputs.out }}/build" -czvf ic-ref.tar.gz ic-ref
+          tar -C "${{ steps.buildit.outputs.out }}" -czvf ic-ref-test.tar.gz build/ic-ref-test test-data
         fi
-        tar -C "${{ steps.buildit.outputs.out }}" -czvf ic-ref-test.tar.gz build test-data
 
         ref_short="$(echo "$GITHUB_SHA" | cut -c1-8)"
         version="${{ steps.get_version.outputs.version }}-$ref_short"


### PR DESCRIPTION
This should decrease the size of the ic-ref-test artifact by omitting the ic-ref binary.