### PR TITLE
add test for timer in post-upgrade on stopped and stopping canister

### DIFF
--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -601,6 +601,7 @@ icTests my_sub other_sub =
   ] ++ [ after AllFinish "($0 ~ /NNS canisters/)" $ testGroup "regular canisters"
   [ simpleTestCase "create and install" ecid $ \_ ->
       return ()
+
   , testCase "create_canister necessary" $
       ic_install'' defaultUser (enum #install) doesn'tExist trivialWasmModule ""
           >>= isErrOrReject [3,5]

--- a/universal-canister/src/api.rs
+++ b/universal-canister/src/api.rs
@@ -64,7 +64,7 @@ mod ic0 {
         pub fn data_certificate_copy(dst: u32, offset: u32, size: u32) -> ();
 
         pub fn time() -> u64;
-        pub fn performance_counter(_type: u32) -> u64;
+        pub fn performance_counter(counter_type: u32) -> u64;
         pub fn global_timer_set(timestamp: u64) -> u64;
         pub fn canister_version() -> u64;
 
@@ -336,8 +336,8 @@ pub fn time() -> u64 {
     unsafe { ic0::time() }
 }
 
-pub fn performance_counter(_type: u32) -> u64 {
-    unsafe { ic0::performance_counter(_type) }
+pub fn performance_counter(counter_type: u32) -> u64 {
+    unsafe { ic0::performance_counter(counter_type) }
 }
 
 pub fn method_name() -> Vec<u8> {
@@ -385,9 +385,7 @@ pub fn trap_with(message: &str) -> ! {
 
 /// Mint cycles (only works on CMC).
 pub fn mint_cycles(amount: u64) -> u64 {
-    unsafe {
-        ic0::mint_cycles(amount)
-    }
+    unsafe { ic0::mint_cycles(amount) }
 }
 
 use std::panic;

--- a/universal-canister/src/lib.rs
+++ b/universal-canister/src/lib.rs
@@ -25,7 +25,7 @@ macro_rules! try_from_u8 {
 }
 
 try_from_u8!(
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Eq, PartialEq)]
     pub enum Ops {
         Noop = 0,
         Drop = 1,
@@ -36,7 +36,7 @@ try_from_u8!(
         Self_ = 6,
         Reject = 7,
         Caller = 8,
-        // = 9,
+        InstructionCounterIsAtLeast = 9,
         RejectMessage = 10,
         RejectCode = 11,
         IntToBlob = 12,
@@ -103,5 +103,6 @@ try_from_u8!(
         CanisterVersion = 73,
         TrapIfNeq = 74,
         MintCycles = 75,
+        OneWayCallNew = 76,
     }
 );


### PR DESCRIPTION
This PR makes the following changes:
- sync universal_canister with IC monorepo
- add one-way calls to universal_canister
- add tests for canister timer in post-upgrade on stopped and stopping canisters to cover a regression in mainnet implementation