### PR TITLE
implement canister range checks in ic-ref-test

### DIFF
--- a/src/IC/CBOR/Utils.hs
+++ b/src/IC/CBOR/Utils.hs
@@ -1,6 +1,9 @@
 module IC.CBOR.Utils where
 
 import qualified Data.ByteString.Builder as BS
+import qualified Data.Text as T
+import Codec.CBOR.Term
+import IC.CBOR.Patterns
 import IC.HTTP.CBOR
 import IC.HTTP.GenR
 import IC.Types
@@ -10,3 +13,12 @@ encodePrincipalList entities = BS.toLazyByteString $ encode $ GList $ map (GBlob
 
 encodeCanisterRangeList :: [CanisterRange] -> Blob
 encodeCanisterRangeList ranges = BS.toLazyByteString $ encode $ GList $ map (\(l, u) -> GList $ map (GBlob . rawEntityId) [l, u]) ranges
+
+parseCanisterRanges :: Term -> Either T.Text [(Blob, Blob)]
+parseCanisterRanges (TList_ ts) = case sequence (map go ts) of
+   Nothing -> Left $ T.pack $ "Cannot parse as Canister Ranges: " ++ show ts
+   Just bs -> Right bs
+  where
+    go (TList_ [ TBlob p1, TBlob p2 ]) = Just (p1, p2)
+    go _ = Nothing
+parseCanisterRanges t = Left $ T.pack $ "Cannot parse as Canister Ranges: " ++ show t

--- a/src/IC/CBOR/Utils.hs
+++ b/src/IC/CBOR/Utils.hs
@@ -1,9 +1,6 @@
 module IC.CBOR.Utils where
 
 import qualified Data.ByteString.Builder as BS
-import qualified Data.Text as T
-import Codec.CBOR.Term
-import IC.CBOR.Patterns
 import IC.HTTP.CBOR
 import IC.HTTP.GenR
 import IC.Types
@@ -13,12 +10,3 @@ encodePrincipalList entities = BS.toLazyByteString $ encode $ GList $ map (GBlob
 
 encodeCanisterRangeList :: [CanisterRange] -> Blob
 encodeCanisterRangeList ranges = BS.toLazyByteString $ encode $ GList $ map (\(l, u) -> GList $ map (GBlob . rawEntityId) [l, u]) ranges
-
-parseCanisterRanges :: Term -> Either T.Text [(Blob, Blob)]
-parseCanisterRanges (TList_ ts) = case sequence (map go ts) of
-   Nothing -> Left $ T.pack $ "Cannot parse as Canister Ranges: " ++ show ts
-   Just bs -> Right bs
-  where
-    go (TList_ [ TBlob p1, TBlob p2 ]) = Just (p1, p2)
-    go _ = Nothing
-parseCanisterRanges t = Left $ T.pack $ "Cannot parse as Canister Ranges: " ++ show t

--- a/src/IC/Id/Forms.hs
+++ b/src/IC/Id/Forms.hs
@@ -15,7 +15,10 @@ mkOpaqueId b =
     b <> BS.singleton 1 <> BS.singleton 1
 
 isOpaqueId :: Blob -> Bool
-isOpaqueId b = BS.drop (BS.length b - 1) b == BS.singleton 1
+isOpaqueId b = BS.drop (BS.length b - 2) b == BS.singleton 1 <> BS.singleton 1
+
+fromOpaqueId :: Blob -> Blob
+fromOpaqueId b = BS.take (BS.length b - 2) b
 
 mkSelfAuthenticatingId :: Blob -> Blob
 mkSelfAuthenticatingId pubkey =

--- a/src/IC/Id/Forms.hs
+++ b/src/IC/Id/Forms.hs
@@ -17,9 +17,6 @@ mkOpaqueId b =
 isOpaqueId :: Blob -> Bool
 isOpaqueId b = BS.drop (BS.length b - 2) b == BS.singleton 1 <> BS.singleton 1
 
-fromOpaqueId :: Blob -> Blob
-fromOpaqueId b = BS.take (BS.length b - 2) b
-
 mkSelfAuthenticatingId :: Blob -> Blob
 mkSelfAuthenticatingId pubkey =
     sha224 pubkey <> BS.singleton 2

--- a/src/IC/Id/Fresh.hs
+++ b/src/IC/Id/Fresh.hs
@@ -1,7 +1,7 @@
 module IC.Id.Fresh where
 
 import IC.Types
-import IC.Id.Forms
+import IC.Id.Forms hiding (Blob)
 
 import Data.ByteString.Builder
 import Data.List
@@ -19,6 +19,9 @@ wordToId = EntityId . mkOpaqueId . toLazyByteString . word64BE
 
 checkCanisterIdInRanges :: [(Word64, Word64)] -> CanisterId -> Bool
 checkCanisterIdInRanges ranges cid = find (\(a, b) -> wordToId a <= cid && cid <= wordToId b) ranges /= Nothing
+
+checkCanisterIdInRanges' :: [(Word64, Word64)] -> Blob -> Bool
+checkCanisterIdInRanges' ranges cid = checkCanisterIdInRanges ranges (EntityId cid)
 
 isRootTestSubnet :: TestSubnetConfig -> Bool
 isRootTestSubnet (_, _, _, ranges) = checkCanisterIdInRanges ranges nns_canister_id

--- a/src/IC/Id/Fresh.hs
+++ b/src/IC/Id/Fresh.hs
@@ -14,14 +14,17 @@ freshId ranges ids =
       [] -> Nothing
       (x:_) -> Just x
 
+wordToId' :: Word64 -> Blob
+wordToId' = mkOpaqueId . toLazyByteString . word64BE
+
 wordToId :: Word64 -> EntityId
-wordToId = EntityId . mkOpaqueId . toLazyByteString . word64BE
+wordToId = EntityId . wordToId'
+
+checkCanisterIdInRanges' :: [(Blob, Blob)] -> Blob -> Bool
+checkCanisterIdInRanges' ranges cid = find (\(a, b) -> a <= cid && cid <= b) ranges /= Nothing
 
 checkCanisterIdInRanges :: [(Word64, Word64)] -> CanisterId -> Bool
-checkCanisterIdInRanges ranges cid = find (\(a, b) -> wordToId a <= cid && cid <= wordToId b) ranges /= Nothing
-
-checkCanisterIdInRanges' :: [(Word64, Word64)] -> Blob -> Bool
-checkCanisterIdInRanges' ranges cid = checkCanisterIdInRanges ranges (EntityId cid)
+checkCanisterIdInRanges ranges cid = checkCanisterIdInRanges' (map (\(a, b) -> (wordToId' a, wordToId' b)) ranges) (rawEntityId cid)
 
 isRootTestSubnet :: TestSubnetConfig -> Bool
 isRootTestSubnet (_, _, _, ranges) = checkCanisterIdInRanges ranges nns_canister_id

--- a/src/IC/Id/Fresh.hs
+++ b/src/IC/Id/Fresh.hs
@@ -4,7 +4,6 @@ import IC.Types
 import IC.Id.Forms hiding (Blob)
 
 import Data.ByteString.Builder
-import Data.List
 import Data.Word
 
 -- Not particulary efficent, but this is a reference implementation, right?
@@ -21,7 +20,7 @@ wordToId :: Word64 -> EntityId
 wordToId = EntityId . wordToId'
 
 checkCanisterIdInRanges' :: [(Blob, Blob)] -> Blob -> Bool
-checkCanisterIdInRanges' ranges cid = find (\(a, b) -> a <= cid && cid <= b) ranges /= Nothing
+checkCanisterIdInRanges' ranges cid = any (\(a, b) -> a <= cid && cid <= b) ranges
 
 checkCanisterIdInRanges :: [(Word64, Word64)] -> CanisterId -> Bool
 checkCanisterIdInRanges ranges cid = checkCanisterIdInRanges' (map (\(a, b) -> (wordToId' a, wordToId' b)) ranges) (rawEntityId cid)

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -509,10 +509,10 @@ validateDelegation cid (Just del) = do
 
 convRange :: HasCallStack => (Blob, Blob) -> IO (Word64, Word64)
 convRange (a, b) = do
-  assertBool "canister IDs must be opaque" $ isOpaqueId a
-  assertBool "canister IDs must be opaque" $ isOpaqueId b
-  a' <- asWord64 $ fromOpaqueId a
-  b' <- asWord64 $ fromOpaqueId b
+  assertBool "Canister IDs must be opaque." $ isOpaqueId a
+  assertBool "Canister IDs must be opaque." $ isOpaqueId b
+  a' <- asWord64BE $ fromOpaqueId a
+  b' <- asWord64BE $ fromOpaqueId b
   return (a', b')
 
 validateStateCert' :: (HasCallStack, HasAgentConfig) => String -> Blob -> Certificate -> IO ()
@@ -700,6 +700,9 @@ asWord32 = runGet Get.getWord32le
 
 asWord64 :: HasCallStack => Blob -> IO Word64
 asWord64 = runGet Get.getWord64le
+
+asWord64BE :: HasCallStack => Blob -> IO Word64
+asWord64BE = runGet Get.getWord64be
 
 as2Word64 :: HasCallStack => Blob -> IO (Word64, Word64)
 as2Word64 = runGet $ (,) <$> Get.getWord64le <*> Get.getWord64le

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -502,18 +502,10 @@ validateDelegation cid (Just del) = do
     tagged_ranges <- certValue cert ["subnet", del_subnet_id del, "canister_ranges"]
     ranges <- case decodeWithTag tagged_ranges >>= parseCanisterRanges of
         Left err -> assertFailure $ "Canister ranges not well formed: " ++ T.unpack err
-        Right ranges -> mapM convRange ranges
+        Right ranges -> return ranges
     assertBool "Effective canister id must belong to the canister ranges of the subnet's delegation." $ checkCanisterIdInRanges' ranges cid
 
     certValue cert ["subnet", del_subnet_id del, "public_key"]
-
-convRange :: HasCallStack => (Blob, Blob) -> IO (Word64, Word64)
-convRange (a, b) = do
-  assertBool "Canister IDs must be opaque." $ isOpaqueId a
-  assertBool "Canister IDs must be opaque." $ isOpaqueId b
-  a' <- asWord64BE $ fromOpaqueId a
-  b' <- asWord64BE $ fromOpaqueId b
-  return (a', b')
 
 validateStateCert' :: (HasCallStack, HasAgentConfig) => String -> Blob -> Certificate -> IO ()
 validateStateCert' what cid cert = do
@@ -700,9 +692,6 @@ asWord32 = runGet Get.getWord32le
 
 asWord64 :: HasCallStack => Blob -> IO Word64
 asWord64 = runGet Get.getWord64le
-
-asWord64BE :: HasCallStack => Blob -> IO Word64
-asWord64BE = runGet Get.getWord64be
 
 as2Word64 :: HasCallStack => Blob -> IO (Word64, Word64)
 as2Word64 = runGet $ (,) <$> Get.getWord64le <*> Get.getWord64le

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -2357,7 +2357,7 @@ icTests my_sub other_sub =
 
     , simpleTestCase "certificate validates" ecid $ \cid -> do
         cert <- getStateCert defaultUser cid []
-        validateStateCert cert
+        validateStateCert cid cert
 
     , testCaseSteps "time is present" $ \step -> do
         cid <- create ecid
@@ -2523,7 +2523,7 @@ icTests my_sub other_sub =
       query cid (replyData getCertificate) >>= extractCertData cid >>= is ""
     , simpleTestCase "validates" ecid $ \cid -> do
       query cid (replyData getCertificate)
-        >>= decodeCert' >>= validateStateCert
+        >>= decodeCert' >>= validateStateCert cid
     , simpleTestCase "present in query method (query call)" ecid $ \cid -> do
       query cid (replyData (i2b getCertificatePresent))
         >>= is "\1\0\0\0"
@@ -3152,7 +3152,7 @@ icTests my_sub other_sub =
           -- Get certificate
           cert <- query cid (replyData getCertificate) >>= decodeCert'
           -- double check it certifies
-          validateStateCert cert
+          validateStateCert cid cert
           certValue cert ["canister", cid, "certified_data"] >>= is (reconstruct tree)
 
           return $ CanisterSig.genSig cert tree

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -2358,7 +2358,7 @@ icTests my_sub other_sub =
 
     , simpleTestCase "certificate does not validate if canister range check fails" ecid $ \cid -> do
         unless my_is_root $ do
-          cert <- getStateCert defaultUser cid [["time"]]
+          cert <- getStateCert defaultUser cid []
           result <- try (validateStateCert other_ecid cert) :: IO (Either DelegationCanisterRangeCheck ())
           assertBool "certificate should not validate" $ isLeft result
 

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -21,6 +21,8 @@ import qualified Data.Map.Lazy as M
 import qualified Data.Set as S
 import qualified Data.Vector as Vec
 import qualified Data.ByteString.Lazy.UTF8 as BLU
+import Control.Exception(try)
+import Data.Either(isLeft)
 import Data.ByteString.Builder
 import Numeric.Natural
 import Data.List
@@ -529,11 +531,12 @@ canister_http_calls sub =
 icTests :: TestSubnetConfig -> TestSubnetConfig -> AgentConfig -> TestTree
 icTests my_sub other_sub =
   let (my_subnet_id_as_entity, my_type, _, ((ecid_as_word64, last_canister_id_as_word64):_)) = my_sub in
-  let (other_subnet_id_as_entity, _, _, _) = other_sub in
+  let (other_subnet_id_as_entity, _, _, ((other_ecid_as_word64, _):_)) = other_sub in
   let my_subnet_id = rawEntityId my_subnet_id_as_entity in
   let other_subnet_id = rawEntityId other_subnet_id_as_entity in
   let my_is_root = isRootTestSubnet my_sub in
   let ecid = rawEntityId $ wordToId ecid_as_word64 in
+  let other_ecid = rawEntityId $ wordToId other_ecid_as_word64 in
   let last_canister_id = rawEntityId $ wordToId last_canister_id_as_word64 in
   let initial_cycles = case my_type of System -> 0
                                        _ -> (2^(60::Int)) in
@@ -2343,12 +2346,6 @@ icTests my_sub other_sub =
           getRequestStatus user cid (requestId req) >>= is (Responded (Reply "\xff\xff"))
 
           return (requestId req)
-        canister_id_in_canister_ranges cid (Just del) = do
-            del_cert <- decodeCert' (del_certificate del)
-            ranges <- certValue @Blob del_cert ["subnet", del_subnet_id del, "canister_ranges"] >>= asCBORBlobPairList
-            cid `isContainedIn` ranges
-            canister_id_in_canister_ranges cid (cert_delegation del_cert)
-        canister_id_in_canister_ranges _ Nothing = return ()
     in
     [ testGroup "required fields" $
         omitFields readStateEmpty $ \req -> do
@@ -2358,6 +2355,12 @@ icTests my_sub other_sub =
     , simpleTestCase "certificate validates" ecid $ \cid -> do
         cert <- getStateCert defaultUser cid []
         validateStateCert cid cert
+
+    , simpleTestCase "certificate does not validate if canister range check fails" ecid $ \cid -> do
+        unless my_is_root $ do
+          cert <- getStateCert defaultUser cid [["time"]]
+          result <- try (validateStateCert other_ecid cert) :: IO (Either DelegationCanisterRangeCheck ())
+          assertBool "certificate should not validate" $ isLeft result
 
     , testCaseSteps "time is present" $ \step -> do
         cid <- create ecid
@@ -2374,11 +2377,6 @@ icTests my_sub other_sub =
         cid <- create ecid
         cert <- getStateCert defaultUser cid [["canister", cid, "controllers"]]
         certValue @Blob cert ["canister", cid, "controllers"] >>= asCBORBlobList >>= isSet [defaultUser]
-
-    , testCase "canister_id included in canister_ranges" $ do
-        cid <- create ecid
-        cert <- getStateCert defaultUser cid [["subnet"]]
-        canister_id_in_canister_ranges cid (cert_delegation cert)
 
     , testCase "module_hash of empty canister" $ do
         cid <- create ecid

--- a/src/IC/Test/Spec/Utils.hs
+++ b/src/IC/Test/Spec/Utils.hs
@@ -140,18 +140,6 @@ cborToBlob :: GenR -> IO Blob
 cborToBlob (GBlob blob) = return blob
 cborToBlob r = assertFailure $ "Expected blob, got " <> show r
 
-asCBORBlobPairList :: Blob -> IO [(Blob, Blob)]
-asCBORBlobPairList blob = do
-    decoded <- asRight $ CBOR.decode blob
-    case decoded of
-        GList list -> do
-            mapM cborToBlobPair list
-        _ -> assertFailure $ "Failed to decode as CBOR encoded list of blob pairs: " <> show decoded
-
-cborToBlobPair :: GenR -> IO (Blob, Blob)
-cborToBlobPair (GList [GBlob x, GBlob y]) = return (x, y)
-cborToBlobPair r = assertFailure $ "Expected list of pairs, got: " <> show r
-
 -- Interaction with aaaaa-aa via the universal canister
 
 ic00viaWithCyclesSubnetImpl' :: HasAgentConfig => Prog -> Prog -> Blob -> Blob -> IC00WithCycles


### PR DESCRIPTION
According to Interface Spec: Delegations are scoped, i.e., they indicate which set of canister principals the delegatee subnet may certify for. This set can be obtained from a delegation `d` using `lookup(["subnet",d.subnet_id,"canister_ranges"],d.certificate)`, which must be present, and is encoded as follows:
```
canister_ranges = tagged<[*canister_range]>
canister_range = [principal principal]
principal = bytes .size (0..29)
tagged<t> = #6.55799(t) ; the CBOR tag
```