### PR TITLE
fix conditions on read_state requests

### DIFF
--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -425,7 +425,7 @@ authReadStateRequest t ecid ev (ReadStateRequest user_id paths) = do
     valid_for ev user_id
     -- Implement ACL for read requests here
     forM_ paths $ \case
-      ["time"] -> return ()
+      ("time":_) -> return ()
       ("subnet":_) -> return ()
       ("canister":cid:"module_hash":_) ->
         assertEffectiveCanisterId ecid (EntityId cid)

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -85,6 +85,7 @@ module IC.Test.Agent
       isPendingOrProcessing,
       isReject,
       isReply,
+      isResponded,
       okCBOR,
       otherSK,
       otherUser,
@@ -568,6 +569,10 @@ getRequestStatus' sender cid rid = do
 
 getRequestStatus :: (HasCallStack, HasAgentConfig) => Blob -> Blob -> Blob -> IO ReqStatus
 getRequestStatus sender cid rid = getRequestStatus' sender cid rid >>= is2xx
+
+isResponded :: ReqStatus -> Assertion
+isResponded (Responded _) = return ()
+isResponded _ = assertFailure "Request must be replied"
 
 loop' :: (HasCallStack, HasAgentConfig) => IO (HTTPErrOr (Maybe a)) -> IO (HTTPErrOr a)
 loop' act = getCurrentTime >>= go

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -572,7 +572,7 @@ getRequestStatus sender cid rid = getRequestStatus' sender cid rid >>= is2xx
 
 isResponded :: ReqStatus -> Assertion
 isResponded (Responded _) = return ()
-isResponded _ = assertFailure "Request must be replied"
+isResponded _ = assertFailure "Request must be responded"
 
 loop' :: (HasCallStack, HasAgentConfig) => IO (HTTPErrOr (Maybe a)) -> IO (HTTPErrOr a)
 loop' act = getCurrentTime >>= go

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -2343,7 +2343,7 @@ icTests my_sub other_sub =
           getRequestStatus user cid (requestId req) >>= is (Responded (Reply "\xff\xff"))
 
           return (requestId req)
-        ensure_provisional_create_canister_request_exists user = do
+        ensure_provisional_create_canister_request_exists ecid user = do
           let arg = empty
                     .+ #amount .== (Just initial_cycles :: Maybe Natural)
                     .+ #settings .== (Nothing :: Maybe Settings)
@@ -2467,9 +2467,10 @@ icTests my_sub other_sub =
         rid2 <- ensure_request_exists cid2 defaultUser
         getStateCert' defaultUser cid [["request_status", rid1], ["request_status", rid2]] >>= code4xx
 
-    , testCase "access denied with different effective canister id" $ do
-        rid <- ensure_provisional_create_canister_request_exists defaultUser
-        getStateCert' defaultUser doesn'tExist [["request_status", rid]] >>= code4xx
+    , simpleTestCase "access denied with different effective canister id" ecid $ \cid -> do
+        cid2 <- install ecid noop
+        rid <- ensure_provisional_create_canister_request_exists cid defaultUser
+        getStateCert' defaultUser cid2 [["request_status", rid]] >>= code4xx
 
     , simpleTestCase "access denied for bogus path" ecid $ \cid -> do
         getStateCert' otherUser cid [["hello", "world"]] >>= code4xx


### PR DESCRIPTION
This MR implements the following fixes of `ic-ref`:
- implement access control for `read_state` requests according to [Interface Spec](https://ic-interface-spec.netlify.app/#http-read-state)
- `create_canister` cannot be called via ingress message