### PR TITLE
make nonexisting canister id in the subnet's ranges

### DIFF
--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -66,7 +66,6 @@ module IC.Test.Agent
       defaultSK,
       defaultUser,
       delegationEnv,
-      doesn'tExist,
       ecdsaSK,
       ecdsaUser,
       enum,
@@ -268,9 +267,6 @@ agentManager :: HasAgentConfig => Manager
 agentManager = tc_manager agentConfig
 
 -- * Test data for some hardcoded user names
-
-doesn'tExist :: Blob
-doesn'tExist = "\xDE\xAD\xBE\xEF" -- hopefully no such canister/user exists
 
 defaultSK :: SecretKey
 defaultSK = createSecretKeyEd25519 "fixed32byteseedfortesting"

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -538,6 +538,7 @@ icTests my_sub other_sub =
   let ecid = rawEntityId $ wordToId ecid_as_word64 in
   let other_ecid = rawEntityId $ wordToId other_ecid_as_word64 in
   let last_canister_id = rawEntityId $ wordToId last_canister_id_as_word64 in
+  let doesn'tExist = rawEntityId $ wordToId (last_canister_id_as_word64 - 1) in
   let initial_cycles = case my_type of System -> 0
                                        _ -> (2^(60::Int)) in
   withAgentConfig $ testGroup "Interface Spec acceptance tests" $
@@ -2361,7 +2362,7 @@ icTests my_sub other_sub =
     [ testGroup "required fields" $ do
         -- TODO: Begin with a succeeding request to a real canister, to rule
         -- out other causes of failure than missing fields
-        omitFields queryToNonExistant $ \req -> do
+        omitFields (queryToNonExistant doesn'tExist) $ \req -> do
           cid <- create ecid
           addExpiry req >>= envelope defaultSK >>= postQueryCBOR cid >>= code4xx
 

--- a/src/IC/Test/Spec/Utils.hs
+++ b/src/IC/Test/Spec/Utils.hs
@@ -62,11 +62,11 @@ trivialWasmModule = "\0asm\1\0\0\0"
 
 -- * Some test data related to standard requests
 
-queryToNonExistant :: GenR
-queryToNonExistant = rec
+queryToNonExistant :: Blob -> GenR
+queryToNonExistant cid = rec
     [ "request_type" =: GText "query"
     , "sender" =: GBlob anonymousUser
-    , "canister_id" =: GBlob doesn'tExist
+    , "canister_id" =: GBlob cid
     , "method_name" =: GText "foo"
     , "arg" =: GBlob "nothing to see here"
     ]


### PR DESCRIPTION
The certificate delegation check fails in ic-ref-test because the nonexisting canister id does not belong to the node's canister ranges. This MR fixes that.