### PR TITLE
increase error msg length limit

### DIFF
--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -428,7 +428,7 @@ submitCall' cid req = do
      assertBool "Response body not empty" (BS.null (responseBody res))
      pure $ Right (getRequestStatus' (senderOf req) cid (requestId req))
   else do
-    let msg = T.unpack (T.decodeUtf8With T.lenientDecode (BS.toStrict (BS.take 200 (responseBody res))))
+    let msg = T.unpack (T.decodeUtf8With T.lenientDecode (BS.toStrict (BS.take 1000 (responseBody res))))
     pure $ Left (code, msg)
 
 submitCall :: (HasCallStack, HasAgentConfig) => Blob -> GenR -> IO (IO (HTTPErrOr ReqStatus))


### PR DESCRIPTION
The error message
```
Specified ingress_expiry not within expected range:
Minimum allowed expiry: 2023-02-01 20:32:37.020911897 UTC
Maximum allowed expiry: 2023-02-01 20:38:07.020911897 UTC
Provided expiry:        2023-02-
```
does not allow one to tell how far off the provided expiry is. This PR is supposed to fix that.