### PR TITLE
.github/workflows/release.yml: skip coverage job on darwin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,12 @@ jobs:
     # run a few targets explicitly, to get easier signal in the CI view
     - run: nix-build-uncached -A universal-canister
     - run: nix-build-uncached -A ic-hs
-    - run: cp -r "$(nix-build -A ic-hs.doc)"/share/doc/*/html gh-page
-    - run: nix-build-uncached -A ic-hs-coverage
-    - run: nix-build-uncached -A coverage
+    - if: matrix.os == 'ubuntu-latest'
+      run: cp -r "$(nix-build -A ic-hs.doc)"/share/doc/*/html gh-page
+    - if: matrix.os == 'ubuntu-latest'
+      run: nix-build-uncached -A ic-hs-coverage
+    - if: matrix.os == 'ubuntu-latest'
+      run: nix-build-uncached -A coverage
     - run: nix-build-uncached -A check-generated
     - run: nix-build-uncached -A ic-ref-dist
     - run: nix-build-uncached -A ic-ref-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,7 @@ jobs:
     - if: matrix.os == 'ubuntu-latest'
       run: nix-build-uncached -A ic-ref-test
     - run: nix-build-uncached -A ic-hs-shell
-    # now the rest
-    - run: nix-build-uncached
+    - run: nix-build-uncached -A license-check
 
   release:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,8 @@ jobs:
       run: nix-build-uncached -A coverage
     - run: nix-build-uncached -A check-generated
     - run: nix-build-uncached -A ic-ref-dist
-    - run: nix-build-uncached -A ic-ref-test
+    - if: matrix.os == 'ubuntu-latest'
+      run: nix-build-uncached -A ic-ref-test
     - run: nix-build-uncached -A ic-hs-shell
     # now the rest
     - run: nix-build-uncached


### PR DESCRIPTION
The GitHub darwin runners only have 14GB of memory. However the `coverage` job requires 17GB which means those machines start swapping which grinds exection to a halt eventually timing out the job.

Since we only care about building the `ic-ref-dist` job on darwin we only run the problematic `coverage` job on linux.