### PR TITLE
Upgrade to GHC-9.4 resulting in lower compile-time memory usage

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -44,8 +44,8 @@ let
           });
 
           all-cabal-hashes = self.fetchurl {
-            url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/35f4996e28c5ba20a3a633346f21abe2072afeb6.tar.gz";
-            sha256 = "sha256-L/PmFUGlBOOd5rAx4NFxv+s2USI9q0YgOsfpdeRDyds=";
+            url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/eddc2bddf45791cb743293d15ad8325fa0e050e4.tar.gz";
+            sha256 = "sha256-5+2pviyhfIeTr1yzbpG56dtP+BxMyEN/w3Tbwz9ePzw=";
           };
 
           # We override secp256k1 since the version in nixpkgs doesn't provide a

--- a/nix/generated/candid.nix
+++ b/nix/generated/candid.nix
@@ -40,7 +40,7 @@
 }:
 mkDerivation {
   pname = "candid";
-  version = "0.4";
+  version = "0.4.0.1";
   src = pkgs.sources.haskell-candid;
   isLibrary = true;
   isExecutable = true;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -6,10 +6,10 @@
         "homepage": null,
         "owner": "nomeata",
         "repo": "haskell-candid",
-        "rev": "87a4f01eb9cb93c827a0a7f5f29af0ee19135308",
-        "sha256": "0mcmj62x49k241k5rpc7j37yczjlcsgyssjwy1ncfs8ss0b8b03r",
+        "rev": "6d60e4464bd4a206d91a6cdade8810a37b09c6d0",
+        "sha256": "0m091vx76dmdwv0ad1y9n2chq28wd24521b8pq305jbqc78zr3rf",
         "type": "tarball",
-        "url": "https://github.com/nomeata/haskell-candid/archive/87a4f01eb9cb93c827a0a7f5f29af0ee19135308.tar.gz",
+        "url": "https://github.com/nomeata/haskell-candid/archive/6d60e4464bd4a206d91a6cdade8810a37b09c6d0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "http-client": {
@@ -64,10 +64,10 @@
         "homepage": "https://github.com/dfinity-side-projects/winter",
         "owner": "dfinity-side-projects",
         "repo": "winter",
-        "rev": "530d5e395bb9919187d47d3966c4d526e668b62a",
-        "sha256": "1mnyhmkilald48p4gl29hq8qqs605nv5z97ps3vln1gn901s2f9c",
+        "rev": "cca827ab9299146c0b3b51920e5ad63c4c6014c3",
+        "sha256": "1cjwdqv4ar7d8pl9zj6rghj682yj54bwwi81d88fsblrbalmnhy1",
         "type": "tarball",
-        "url": "https://github.com/dfinity-side-projects/winter/archive/530d5e395bb9919187d47d3966c4d526e668b62a.tar.gz",
+        "url": "https://github.com/dfinity-side-projects/winter/archive/cca827ab9299146c0b3b51920e5ad63c4c6014c3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/IC/Canister/Snapshot.hs
+++ b/src/IC/Canister/Snapshot.hs
@@ -29,7 +29,7 @@ instance SnapshotAble ImpState where
         Stable.imp (isStableMem rs) pmem
         return rs
       where
-        trapToFail (Trap err) = fail $ "replay failed: " ++ show err
+        trapToFail (Trap err) = error $ "replay failed: " ++ show err
         trapToFail (Return x) = return x
 
 deriving

--- a/src/IC/Crypto/Ed25519.hs
+++ b/src/IC/Crypto/Ed25519.hs
@@ -6,6 +6,7 @@ module IC.Crypto.Ed25519
  , verify
  ) where
 
+import Data.Maybe (fromJust)
 import qualified Data.ByteString.Lazy as BS
 import qualified Crypto.Sign.Ed25519 as Ed25519
 
@@ -16,7 +17,7 @@ createKey seed | BS.length seed > 32 = error "Seed too long"
 createKey seed = sk
   where
     seed' = seed <> BS.replicate (32 - BS.length seed) 0x00
-    Just (_, sk) = Ed25519.createKeypairFromSeed_ (BS.toStrict seed')
+    (_, sk) = fromJust $ Ed25519.createKeypairFromSeed_ (BS.toStrict seed')
 
 toPublicKey :: SecretKey -> BS.ByteString
 toPublicKey = BS.fromStrict . Ed25519.unPublicKey . Ed25519.toPublicKey

--- a/src/IC/Purify.hs
+++ b/src/IC/Purify.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeOperators #-}
 module IC.Purify where
 
 import Control.Monad.ST
@@ -58,4 +59,3 @@ instance Purify a (Replay a) where
       return (replay', x)
     where
       replay' = Replay $ do x <- replay; void (act x); return x
-

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -131,6 +131,7 @@ import qualified Text.Hex as H
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Builder as BS
 import qualified Data.HashMap.Lazy as HM
+import Data.Maybe (fromJust)
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS
 import Network.HTTP.Types
@@ -883,5 +884,5 @@ toHash256 = Get.runGet Get.get
 
 verifySignature :: Blob -> Blob -> Blob -> Bool
 verifySignature msg sig key = Haskoin.verifyHashSig (toHash256 msg) s pk
-  where Just pk = Haskoin.importPubKey $ BS.toStrict key
-        Just s  = Haskoin.decodeStrictSig $ BS.toStrict sig
+  where pk = fromJust $ Haskoin.importPubKey $ BS.toStrict key
+        s  = fromJust $ Haskoin.decodeStrictSig $ BS.toStrict sig

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -63,8 +63,10 @@ import qualified IC.Test.Spec.TECDSA
 
 icTests :: TestSubnetConfig -> TestSubnetConfig -> AgentConfig -> TestTree
 icTests my_sub other_sub =
-  let (my_subnet_id_as_entity, my_type, _, ((ecid_as_word64, last_canister_id_as_word64):_)) = my_sub in
-  let (other_subnet_id_as_entity, _, _, ((other_ecid_as_word64, _):_)) = other_sub in
+  let (my_subnet_id_as_entity, my_type, _, my_ranges) = my_sub in
+  let (ecid_as_word64, last_canister_id_as_word64) = head my_ranges in
+  let (other_subnet_id_as_entity, _, _, other_ranges) = other_sub in
+  let (other_ecid_as_word64, _) = head other_ranges in
   let my_subnet_id = rawEntityId my_subnet_id_as_entity in
   let other_subnet_id = rawEntityId other_subnet_id_as_entity in
   let my_is_root = isRootTestSubnet my_sub in

--- a/src/IC/Test/Spec/HTTP.hs
+++ b/src/IC/Test/Spec/HTTP.hs
@@ -121,7 +121,8 @@ check_http_body = aux . fromUtf8
 
 canister_http_calls :: HasAgentConfig => TestSubnetConfig -> [TestTree]
 canister_http_calls sub =
-  let (_, _, _, ((ecid_as_word64, _):_)) = sub in
+  let (_, _, _, ranges) = sub in
+  let (ecid_as_word64, _) = head ranges in
   let ecid = rawEntityId $ wordToId ecid_as_word64 in
   [
     -- "Currently, the GET, HEAD, and POST methods are supported for HTTP requests."


### PR DESCRIPTION
Building ic-hs with GHC-9.0 requires ~13GB of memory. Upgrading to GHC-9.4 reduces this ~9GB:

![Screenshot 2023-02-28 at 17 21 31](https://user-images.githubusercontent.com/576355/221920554-407ffc2c-01fd-4c88-8444-dfdbb70746b1.png)
