### PR TITLE
can request at most one request_status path in read_state

### DIFF
--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -138,6 +138,9 @@ authReadStateRequest :: RequestValidation m => Timestamp -> CanisterId -> EnvVal
 authReadStateRequest t ecid ev (ReadStateRequest user_id paths) = do
     valid_when ev t
     valid_for ev user_id
+    let num_request_status_paths = sum $ map is_request_status paths
+    unless (num_request_status_paths <= 1) $
+      throwError "Can only request up to 1 path for request_status."
     -- Implement ACL for read requests here
     forM_ paths $ \case
       ("time":_) -> return ()
@@ -170,6 +173,10 @@ authReadStateRequest t ecid ev (ReadStateRequest user_id paths) = do
             valid_where ev (calleeOfCallRequest ar)
           Nothing -> return ()
       _ -> throwError "User is not authorized to read unspecified state paths"
+  where
+    is_request_status :: Path -> Integer
+    is_request_status ("request_status":_) = 1
+    is_request_status _ = 0
 
 -- Synchronous requests
 

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -1825,11 +1825,14 @@ icTests my_sub other_sub =
         | rid <- [ BS.replicate 32 0, BS.replicate 32 8, BS.replicate 32 255 ]
         ]
 
-    , simpleTestCase "can ask for portion of request status " ecid $ \cid -> do
+    , simpleTestCase "can ask for portion of request status (status)" ecid $ \cid -> do
         rid <- ensure_request_exists cid defaultUser
-        cert <- getStateCert defaultUser cid
-          [["request_status", rid, "status"], ["request_status", rid, "reply"]]
+        cert <- getStateCert defaultUser cid [["request_status", rid, "status"]]
         void $ certValue @T.Text cert ["request_status", rid, "status"]
+
+    , simpleTestCase "can ask for portion of request status (reply)" ecid $ \cid -> do
+        rid <- ensure_request_exists cid defaultUser
+        cert <- getStateCert defaultUser cid [["request_status", rid, "reply"]]
         void $ certValue @Blob cert ["request_status", rid, "reply"]
 
     , simpleTestCase "access denied for other users request" ecid $ \cid -> do
@@ -1839,9 +1842,7 @@ icTests my_sub other_sub =
     , simpleTestCase "reading two statuses to same canister in one go" ecid $ \cid -> do
         rid1 <- ensure_request_exists cid defaultUser
         rid2 <- ensure_request_exists cid defaultUser
-        cert <- getStateCert defaultUser cid [["request_status", rid1], ["request_status", rid2]]
-        void $ certValue @T.Text cert ["request_status", rid1, "status"]
-        void $ certValue @T.Text cert ["request_status", rid2, "status"]
+        getStateCert' defaultUser cid [["request_status", rid1], ["request_status", rid2]] >>= code4xx
 
     , simpleTestCase "access denied for other users request (mixed request)" ecid $ \cid -> do
         rid1 <- ensure_request_exists cid defaultUser


### PR DESCRIPTION
The Interface Spec says
```
Read state requests containing many requested paths might be rejected with a 4xx HTTP status code.

NOTE
The Internet Computer blockchain mainnet might reject read state requests that request more than 1 path with prefix /request_status/<request_id>.
```
This PR enforces the bound of at most one path with prefix `/request_status/<request_id>` and updates the test suite so that we can enforce the same limit in the mainnet implementation.