### PR TITLE
check the number of delegations in sender_delegation

### DIFF
--- a/src/IC/HTTP/Request.hs
+++ b/src/IC/HTTP/Request.hs
@@ -40,7 +40,9 @@ stripEnvelope root_key gr = runWriterT $ flip record gr $ do
                 throwError "Public key not authorized to sign for user"
 
             delegations <- optionalField (listOf delegationField) "sender_delegation"
-            pk' <- checkDelegations pk [pk] (fromMaybe [] delegations)
+            let dels = fromMaybe [] delegations
+            when (length dels > 4) $ throwError "sender_delegation must not contain more than four delegations"
+            pk' <- checkDelegations pk [pk] dels
 
             let rid = requestId content
             lift $ lift $

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -2518,7 +2518,7 @@ icTests my_sub other_sub =
       , ("empty delegations",  otherUser,         delEnv [])
       , ("three delegations",  otherUser,         delEnv [ed25519SK2, ed25519SK3])
       , ("four delegations",   otherUser,         delEnv [ed25519SK2, ed25519SK3, ed25519SK4])
-      , ("mixed delegations",  otherUser,         delEnv [defaultSK, webAuthnECDSASK, webAuthnRSASK, ecdsaSK, secp256k1SK])
+      , ("mixed delegations",  otherUser,         delEnv [defaultSK, webAuthnRSASK, ecdsaSK, secp256k1SK])
       ] $ \ (name, user, env) ->
     [ simpleTestCase (name ++ " in query") ecid $ \cid -> do
       req <- addExpiry $ rec

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -2486,6 +2486,10 @@ icTests my_sub other_sub =
       withEd25519 [Just [], Just [cid]]
     , badTestCase "two delegations, second empty target set" callReq $ \cid ->
       withEd25519 [Just [cid], Just []]
+    , goodTestCase "four delegations" callReq $ \cid ->
+      withEd25519 $ take 4 $ repeat $ Just [cid]
+    , badTestCase "too many delegations" callReq $ \cid ->
+      withEd25519 $ take 5 $ repeat $ Just [cid]
     , badTestCase "self-loop in delegations" callReq $ \cid ->
       withSelfLoop [Just [cid], Just [cid]]
     , badTestCase "cycle in delegations" callReq $ \cid ->


### PR DESCRIPTION
Interface Spec says: "The delegation field, if present, must not contain more than four delegations."

This MR implements the above sentence in the reference implementation and its test suite.