### PR TITLE
fire canister http tests in batches

### DIFF
--- a/src/IC/Test/Spec/HTTP.hs
+++ b/src/IC/Test/Spec/HTTP.hs
@@ -126,14 +126,14 @@ canister_http_calls sub =
   [
     -- "Currently, the GET, HEAD, and POST methods are supported for HTTP requests."
 
-    simpleTestCase "GET call" ecid $ \cid -> do
+    simpleTestCase "HTTP01: GET call" ecid $ \cid -> do
       let s = "hello_world"
       resp <- ic_http_get_request (ic00viaWithCyclesRefund 0 cid) sub ("ascii/" ++ s) (Just 666) Nothing cid
       (resp .! #status) @?= 200
       (resp .! #body) @?= BLU.fromString s
       check_http_response resp
 
-    , simpleTestCase "POST call" ecid $ \cid -> do
+    , simpleTestCase "HTTP01: POST call" ecid $ \cid -> do
       let b = toUtf8 $ T.pack $ "Hello, world!"
       let hs = [(T.pack "Name1", T.pack "value1"), (T.pack "Name2", T.pack "value2")]
       resp <- ic_http_post_request (ic00viaWithCyclesRefund 0 cid) sub "anything" (Just 666) (Just b) (vec_header_from_list_text hs) Nothing cid
@@ -141,7 +141,7 @@ canister_http_calls sub =
       check_http_response resp
       check_http_json "POST" hs b $ (decode (resp .! #body) :: Maybe HttpRequest)
 
-    , simpleTestCase "HEAD call" ecid $ \cid -> do
+    , simpleTestCase "HTTP01: HEAD call" ecid $ \cid -> do
       let n = 6666
       let b = toUtf8 $ T.pack $ replicate n 'x'
       let hs = [(T.pack "Name1", T.pack "value1"), (T.pack "Name2", T.pack "value2")]
@@ -156,14 +156,14 @@ canister_http_calls sub =
 
     -- "For security reasons, only HTTPS connections are allowed (URLs must start with https://)."
 
-    , testCase "url must start with https://" $ do
+    , testCase "HTTP01: url must start with https://" $ do
       let s = "hello_world"
       cid <- install ecid noop
       ic_http_get_request' (ic00viaWithCyclesRefund 0 cid) sub "http://" ("ascii/" ++ s) Nothing Nothing cid >>= isReject [1]
 
     -- "The size of an HTTP request from the canister is the total number of bytes representing the names and values of HTTP headers and the HTTP body. The maximal size for the request from the canister is 2MB (2,000,000B)."
 
-    , simpleTestCase "maximum possible request size" ecid $ \cid -> do
+    , simpleTestCase "HTTP01: maximum possible request size" ecid $ \cid -> do
       let hs = [(T.pack "Name1", T.pack "value1"), (T.pack "Name2", T.pack "value2"), (T.pack "Content-Type", T.pack "text/html; charset=utf-8")]
       let len_hs = sum $ map (\(n, v) -> utf8_length n + utf8_length v) hs
       let b = toUtf8 $ T.pack $ replicate (fromIntegral $ max_request_bytes_limit - len_hs) 'x'
@@ -173,7 +173,7 @@ canister_http_calls sub =
       let n = read (T.unpack $ fromJust $ fromUtf8 (resp .! #body)) :: Word64
       assertBool ("Request size must be at least (the HTTP client can add more headers) " ++ show max_request_bytes_limit) $ n >= len_hs + fromIntegral (BS.length b)
 
-    , simpleTestCase "maximum possible request size exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP01:/)" $ simpleTestCase "HTTP02: maximum possible request size exceeded" ecid $ \cid -> do
       let hs = [(T.pack "Name1", T.pack "value1"), (T.pack "Name2", T.pack "value2"), (T.pack "Content-Type", T.pack "text/html; charset=utf-8")]
       let len_hs = sum $ map (\(n, v) -> utf8_length n + utf8_length v) hs
       let b = toUtf8 $ T.pack $ replicate (fromIntegral $ max_request_bytes_limit - len_hs + 1) 'x'
@@ -181,7 +181,7 @@ canister_http_calls sub =
 
     -- "The size of an HTTP response from the remote server is the total number of bytes representing the names and values of HTTP headers and the HTTP body. Each request can specify a maximal size for the response from the remote HTTP server."
 
-    , simpleTestCase "small maximum possible response size" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP01:/)" $ simpleTestCase "HTTP02: small maximum possible response size" ecid $ \cid -> do
       let s = "hello_world"
       {- Response headers (size: 136)
           Connection: keep-alive
@@ -196,7 +196,7 @@ canister_http_calls sub =
       (resp .! #body) @?= BLU.fromString s
       check_http_response resp
 
-    , simpleTestCase "small maximum possible response size exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP01:/)" $ simpleTestCase "HTTP02: small maximum possible response size exceeded" ecid $ \cid -> do
       let s = "hello_world"
       {- Response headers (size: 136)
           Connection: keep-alive
@@ -208,7 +208,7 @@ canister_http_calls sub =
       let header_size = 136
       ic_http_get_request' (ic00viaWithCyclesRefund 0 cid) sub "https://" ("ascii/" ++ s) (Just $ fromIntegral $ length s + header_size - 1) Nothing cid >>= isReject [1]
 
-    , simpleTestCase "small maximum possible response size (only headers)" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP01:/)" $ simpleTestCase "HTTP02: small maximum possible response size (only headers)" ecid $ \cid -> do
       {- Response headers (size: 136)
           Connection: keep-alive
           Content-Type: application/octet-stream
@@ -222,7 +222,7 @@ canister_http_calls sub =
       (resp .! #body) @?= BS.empty
       check_http_response resp
 
-    , simpleTestCase "small maximum possible response size (only headers) exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP01:/)" $ simpleTestCase "HTTP02: small maximum possible response size (only headers) exceeded" ecid $ \cid -> do
       {- Response headers (size: 136)
           Connection: keep-alive
           Content-Type: application/octet-stream
@@ -235,7 +235,7 @@ canister_http_calls sub =
 
     -- "The upper limit on the maximal size for the response is 2MB (2,000,000B) and this value also applies if no maximal size value is specified."
 
-    , testCase "large maximum possible response size" $ do
+    , after AllFinish "($0 ~ /HTTP02:/)" $ testCase "HTTP03: large maximum possible response size" $ do
       {- Response headers (size: 141)
           Connection: keep-alive
           Content-Type: application/octet-stream
@@ -250,7 +250,7 @@ canister_http_calls sub =
       (resp .! #body) @?= "Dummy!"
       check_http_response resp
 
-    , testCase "large maximum possible response size exceeded" $ do
+    , after AllFinish "($0 ~ /HTTP02:/)" $ testCase "HTTP03: large maximum possible response size exceeded" $ do
       {- Response headers (size: 141)
           Connection: keep-alive
           Content-Type: application/octet-stream
@@ -264,34 +264,34 @@ canister_http_calls sub =
 
     -- "The URL must be valid according to RFC-3986 and its length must not exceed 8192."
 
-    , simpleTestCase "non-ascii URL" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP02:/)" $ simpleTestCase "HTTP03: non-ascii URL" ecid $ \cid -> do
       ic_http_get_request' (ic00viaWithCyclesRefund 0 cid) sub "https://" "ascii/안녕하세요" Nothing Nothing cid >>= isReject [1]
 
-    , simpleTestCase "maximum possible url size" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP02:/)" $ simpleTestCase "HTTP03: maximum possible url size" ecid $ \cid -> do
       resp <- ic_long_url_http_request (ic00viaWithCyclesRefund 0 cid) sub "https://" max_http_request_url_length Nothing cid
       (resp .! #status) @?= 200
       assertBool "HTTP response body is malformed" $ check_http_body $ resp .! #body
       check_http_response resp
 
-    , simpleTestCase "maximum possible url size exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP02:/)" $ simpleTestCase "HTTP03: maximum possible url size exceeded" ecid $ \cid -> do
       ic_long_url_http_request' (\fee -> ic00viaWithCyclesRefund fee cid fee) sub "https://" (max_http_request_url_length + 1) Nothing cid >>= isReject [4]
 
     -- "max_response_bytes - If provided, the value must not exceed 2MB (2,000,000B)."
 
-    , simpleTestCase "maximum possible value of max_response_bytes" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP03:/)" $ simpleTestCase "HTTP04: maximum possible value of max_response_bytes" ecid $ \cid -> do
       let s = "hello_world"
       resp <- ic_http_get_request (ic00viaWithCyclesRefund 0 cid) sub ("ascii/" ++ s) (Just max_response_bytes_limit) Nothing cid
       (resp .! #status) @?= 200
       (resp .! #body) @?= BLU.fromString s
       check_http_response resp
 
-    , simpleTestCase "maximum possible value of max_response_bytes exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP03:/)" $ simpleTestCase "HTTP04: maximum possible value of max_response_bytes exceeded" ecid $ \cid -> do
       let s = "hello_world"
       ic_http_get_request' (\fee -> ic00viaWithCyclesRefund fee cid fee) sub "https://" ("ascii/" ++ s) (Just $ max_response_bytes_limit + 1) Nothing cid >>= isReject [4]
 
     -- "transform - an optional record that includes a function that transforms raw responses to sanitized responses, and a byte-encoded context that is provided to the function upon invocation, along with the response to be sanitized."
 
-    , testCase "call with simple transform" $ do
+    , after AllFinish "($0 ~ /HTTP03:/)" $ testCase "HTTP04: call with simple transform" $ do
       let b = toUtf8 $ T.pack $ "Hello, world!"
       let hs = vec_header_from_list_text [(T.pack "Name1", T.pack "value1"), (T.pack "Name2", T.pack "value2")]
       cid <- install ecid (onTransform (callback (replyData (bytes (Candid.encode dummyResponse)))))
@@ -300,7 +300,7 @@ canister_http_calls sub =
       (resp .! #body) @?= "Dummy!"
       check_http_response resp
 
-    , testCase "reflect transform context" $ do
+    , after AllFinish "($0 ~ /HTTP03:/)" $ testCase "HTTP04: reflect transform context" $ do
       let s = "hello_world"
       cid <- install ecid (onTransform (callback (replyData (getHttpReplyWithBody (getHttpTransformContext argData)))))
       resp <- ic_http_get_request (ic00viaWithCyclesRefund 0 cid) sub ("ascii/" ++ s) Nothing (Just ("transform", "asdf")) cid
@@ -309,12 +309,12 @@ canister_http_calls sub =
 
     -- "If provided, the calling canister itself must export this (transform) function."
 
-    , testCase "non-existent transform function" $ do
+    , after AllFinish "($0 ~ /HTTP03:/)" $ testCase "HTTP04: non-existent transform function" $ do
       let s = "hello_world"
       cid <- install ecid noop
       ic_http_get_request' (ic00viaWithCyclesRefund 0 cid) sub "https://" ("ascii/" ++ s) Nothing (Just ("nonExistent", "")) cid >>= isReject [3]
 
-    , testCase "reference to a transform function exposed by another canister" $ do
+    , after AllFinish "($0 ~ /HTTP04:/)" $ testCase "HTTP05: reference to a transform function exposed by another canister" $ do
       let s = "hello_world"
       cid <- install ecid noop
       cid2 <- install ecid (onTransform (callback (replyData (bytes (Candid.encode dummyResponse)))))
@@ -322,7 +322,7 @@ canister_http_calls sub =
 
     -- "The maximal number of bytes representing the response produced by the transform function is 2MB (2,000,000B)."
 
-    , testCase "maximum possible canister response size" $ do
+    , after AllFinish "($0 ~ /HTTP04:/)" $ testCase "HTTP05: maximum possible canister response size" $ do
       {- Response headers (size: 141)
           Connection: keep-alive
           Content-Type: application/octet-stream
@@ -339,7 +339,7 @@ canister_http_calls sub =
       (resp .! #status) @?= 200
       (resp .! #body) @?= bodyOfSize maximumSizeResponseBodySize
 
-    , testCase "maximum possible canister response size exceeded" $ do
+    , after AllFinish "($0 ~ /HTTP04:/)" $ testCase "HTTP05: maximum possible canister response size exceeded" $ do
       {- Response headers (size: 141)
           Connection: keep-alive
           Content-Type: application/octet-stream
@@ -356,7 +356,7 @@ canister_http_calls sub =
 
     -- "When the transform function is invoked by the system due to a canister HTTP request, the caller's identity is the principal of the management canister."
 
-    , testCase "check caller of transform" $ do
+    , after AllFinish "($0 ~ /HTTP04:/)" $ testCase "HTTP05: check caller of transform" $ do
       let s = "hello_world"
       cid <- install ecid (onTransform (callback (replyData (getHttpReplyWithBody (parsePrincipal caller)))))
       resp <- ic_http_get_request (ic00viaWithCyclesRefund 0 cid) sub ("ascii/" ++ s) Nothing (Just ("transform", "caller")) cid
@@ -365,7 +365,7 @@ canister_http_calls sub =
 
     -- "The following additional limits apply to HTTP requests and HTTP responses from the remote sever: the number of headers must not exceed 64."
 
-    , simpleTestCase "maximum number of request headers" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP04:/)" $ simpleTestCase "HTTP05: maximum number of request headers" ecid $ \cid -> do
       let b = toUtf8 $ T.pack $ "Hello, world!"
       let hs = [(T.pack ("Name" ++ show i), T.pack ("value" ++ show i)) | i <- [0..http_headers_max_number - 1]]
       resp <- ic_http_post_request (ic00viaWithCyclesRefund 0 cid) sub "anything" Nothing (Just b) (vec_header_from_list_text hs) Nothing cid
@@ -373,12 +373,12 @@ canister_http_calls sub =
       check_http_response resp
       check_http_json "POST" hs b $ (decode (resp .! #body) :: Maybe HttpRequest)
 
-    , simpleTestCase "maximum number of request headers exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP05:/)" $ simpleTestCase "HTTP06: maximum number of request headers exceeded" ecid $ \cid -> do
       let b = toUtf8 $ T.pack $ "Hello, world!"
       let hs = [(T.pack ("Name" ++ show i), T.pack ("value" ++ show i)) | i <- [0..http_headers_max_number]]
       ic_http_post_request' (\fee -> ic00viaWithCyclesRefund fee cid fee) sub "anything" Nothing (Just b) (vec_header_from_list_text hs) Nothing cid >>= isReject [4]
 
-    , simpleTestCase "maximum number of response headers" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP05:/)" $ simpleTestCase "HTTP06: maximum number of response headers" ecid $ \cid -> do
       {- These 5 response headers are always included:
           Connection: keep-alive
           Content-Type: text/html; charset=utf-8
@@ -393,7 +393,7 @@ canister_http_calls sub =
       assertBool "Response HTTP headers have not been received properly." $ list_subset (map_to_lower hs) (map_to_lower $ http_response_headers resp)
       check_http_response resp
 
-    , simpleTestCase "maximum number of response headers exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP05:/)" $ simpleTestCase "HTTP06: maximum number of response headers exceeded" ecid $ \cid -> do
       {- These 5 response headers are always included:
           Connection: keep-alive
           Content-Type: text/html; charset=utf-8
@@ -406,7 +406,7 @@ canister_http_calls sub =
 
     -- "The following additional limits apply to HTTP requests and HTTP responses from the remote sever: the number of bytes representing a header name must not exceed 8KiB."
 
-    , simpleTestCase "maximum request header name length" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP05:/)" $ simpleTestCase "HTTP06: maximum request header name length" ecid $ \cid -> do
       let b = toUtf8 $ T.pack $ "Hello, world!"
       let hs = [(T.pack (replicate (fromIntegral http_headers_max_name_value_length) 'x'), T.pack ("value"))]
       resp <- ic_http_post_request (ic00viaWithCyclesRefund 0 cid) sub "anything" Nothing (Just b) (vec_header_from_list_text hs) Nothing cid
@@ -414,12 +414,12 @@ canister_http_calls sub =
       check_http_response resp
       check_http_json "POST" hs b $ (decode (resp .! #body) :: Maybe HttpRequest)
 
-    , simpleTestCase "maximum request header name length exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP05:/)" $ simpleTestCase "HTTP06: maximum request header name length exceeded" ecid $ \cid -> do
       let b = toUtf8 $ T.pack $ "Hello, world!"
       let hs = [(T.pack (replicate (fromIntegral $ http_headers_max_name_value_length + 1) 'x'), T.pack ("value"))]
       ic_http_post_request' (\fee -> ic00viaWithCyclesRefund fee cid fee) sub "anything" Nothing (Just b) (vec_header_from_list_text hs) Nothing cid >>= isReject [4]
 
-    , simpleTestCase "maximum response header name length" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP06:/)" $ simpleTestCase "HTTP07: maximum response header name length" ecid $ \cid -> do
       let n = http_headers_max_name_value_length
       let hs = [(T.pack $ replicate (fromIntegral n) 'x', T.pack "value")]
       resp <- ic_http_get_request (ic00viaWithCyclesRefund 0 cid) sub ("long_response_header_name/" ++ show n) Nothing Nothing cid
@@ -427,13 +427,13 @@ canister_http_calls sub =
       assertBool "Response HTTP headers have not been received properly." $ list_subset (map_to_lower hs) (map_to_lower $ http_response_headers resp)
       check_http_response resp
 
-    , simpleTestCase "maximum response header name length exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP06:/)" $ simpleTestCase "HTTP07: maximum response header name length exceeded" ecid $ \cid -> do
       let n = http_headers_max_name_value_length + 1
       ic_http_get_request' (ic00viaWithCyclesRefund 0 cid) sub "https://" ("long_response_header_name/" ++ show n) Nothing Nothing cid >>= isReject [1]
 
     -- "The following additional limits apply to HTTP requests and HTTP responses from the remote sever: the number of bytes representing a header value must not exceed 8KiB."
 
-    , simpleTestCase "maximum request header value length" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP06:/)" $ simpleTestCase "HTTP07: maximum request header value length" ecid $ \cid -> do
       let b = toUtf8 $ T.pack $ "Hello, world!"
       let hs = [(T.pack "name", T.pack (replicate (fromIntegral http_headers_max_name_value_length) 'x'))]
       resp <- ic_http_post_request (ic00viaWithCyclesRefund 0 cid) sub "anything" Nothing (Just b) (vec_header_from_list_text hs) Nothing cid
@@ -441,12 +441,12 @@ canister_http_calls sub =
       check_http_response resp
       check_http_json "POST" hs b $ (decode (resp .! #body) :: Maybe HttpRequest)
 
-    , simpleTestCase "maximum request header value length exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP06:/)" $ simpleTestCase "HTTP07: maximum request header value length exceeded" ecid $ \cid -> do
       let b = toUtf8 $ T.pack $ "Hello, world!"
       let hs = [(T.pack "name", T.pack (replicate (fromIntegral $ http_headers_max_name_value_length + 1) 'x'))]
       ic_http_post_request' (\fee -> ic00viaWithCyclesRefund fee cid fee) sub "anything" Nothing (Just b) (vec_header_from_list_text hs) Nothing cid >>= isReject [4]
 
-    , simpleTestCase "maximum response header value length" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP06:/)" $ simpleTestCase "HTTP07: maximum response header value length" ecid $ \cid -> do
       let n = http_headers_max_name_value_length
       let hs = [(T.pack "name", T.pack $ replicate (fromIntegral n) 'x')]
       resp <- ic_http_get_request (ic00viaWithCyclesRefund 0 cid) sub ("long_response_header_value/" ++ show n) Nothing Nothing cid
@@ -454,13 +454,13 @@ canister_http_calls sub =
       assertBool "Response HTTP headers have not been received properly." $ list_subset (map_to_lower hs) (map_to_lower $ http_response_headers resp)
       check_http_response resp
 
-    , simpleTestCase "maximum response header value length exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP07:/)" $ simpleTestCase "HTTP08: maximum response header value length exceeded" ecid $ \cid -> do
       let n = http_headers_max_name_value_length + 1
       ic_http_get_request' (ic00viaWithCyclesRefund 0 cid) sub "https://" ("long_response_header_value/" ++ show n) Nothing Nothing cid >>= isReject [1]
 
     -- "The following additional limits apply to HTTP requests and HTTP responses from the remote sever: the total number of bytes representing the header names and values must not exceed 48KiB."
 
-    , simpleTestCase "maximum request total header size" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP07:/)" $ simpleTestCase "HTTP08: maximum request total header size" ecid $ \cid -> do
       let chunk = http_headers_max_name_value_length
       assertBool ("Maximum number of bytes to represent all request header names and value is not divisible by " ++ show (2 * chunk)) (http_headers_max_total_size `mod` (2 * chunk) == 0)
       assertBool ("Maximum number of bytes to represent all request header names and value exceeds " ++ show (2 * chunk * 26)) (http_headers_max_total_size `div` (2 * chunk) <= fromIntegral (min 26 http_headers_max_number))
@@ -472,7 +472,7 @@ canister_http_calls sub =
       check_http_response resp
       check_http_json "POST" hs b $ (decode (resp .! #body) :: Maybe HttpRequest)
 
-    , simpleTestCase "maximum request total header size exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP07:/)" $ simpleTestCase "HTTP08: maximum request total header size exceeded" ecid $ \cid -> do
       let chunk = http_headers_max_name_value_length
       assertBool ("Maximum number of bytes to represent all request header names and value is not divisible by " ++ show (2 * chunk)) (http_headers_max_total_size `mod` (2 * chunk) == 0)
       assertBool ("Maximum number of bytes to represent all request header names and value exceeds " ++ show (2 * chunk * 26)) (http_headers_max_total_size `div` (2 * chunk) <= fromIntegral (min 26 http_headers_max_number))
@@ -481,14 +481,14 @@ canister_http_calls sub =
       let hs = (T.pack "x", T.empty) : [(T.pack $ [charFromInt i] ++ replicate (fromIntegral chunk - 1) 'x', T.pack $ replicate (fromIntegral chunk) 'x') | i <- [0..fromIntegral n - 1]]
       ic_http_post_request' (\fee -> ic00viaWithCyclesRefund fee cid fee) sub "anything" Nothing (Just b) (vec_header_from_list_text hs) Nothing cid >>= isReject [4]
 
-    , simpleTestCase "maximum response total header size" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP07:/)" $ simpleTestCase "HTTP08: maximum response total header size" ecid $ \cid -> do
       let n = http_headers_max_total_size
       resp <- ic_http_get_request (ic00viaWithCyclesRefund 0 cid) sub ("large_response_total_header_size/" ++ show http_headers_max_name_value_length ++ "/" ++ show n) Nothing Nothing cid
       (resp .! #status) @?= 200
       assertBool ("Total header size is not equal to " ++ show n) $ http_response_headers_total_size resp == n
       check_http_response resp
 
-    , simpleTestCase "maximum response total header size exceeded" ecid $ \cid -> do
+    , after AllFinish "($0 ~ /HTTP07:/)" $ simpleTestCase "HTTP08: maximum response total header size exceeded" ecid $ \cid -> do
       let n = http_headers_max_total_size + 1
       ic_http_get_request' (ic00viaWithCyclesRefund 0 cid) sub "https://" ("large_response_total_header_size/" ++ show http_headers_max_name_value_length ++ "/" ++ show n) Nothing Nothing cid >>= isReject [1]
   ]


### PR DESCRIPTION
This PR fires canister http tests in sequential batches of 5 tests per batch so that the httpbin server is not overloaded with requests.