### PR TITLE
drop nix-build-uncached

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,6 @@ jobs:
       with:
         name: ic-hs-test
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - if: matrix.os == 'macos-latest'
-      run: nix-env -iA nix-build-uncached -f nix/
     # until https://github.com/cachix/cachix-action/issues/86 is fixed:
     - run: cachix watch-store ic-hs-test &
 
@@ -44,12 +42,12 @@ jobs:
     - if: matrix.os == 'ubuntu-latest'
       run: nix build -f default.nix --eval-store auto --store ssh-ng://eu.nixbuild.net --builders "" --max-jobs 2 --no-link --print-build-logs universal-canister
     - if: matrix.os == 'macos-latest'
-      run: nix-build-uncached -A universal-canister
+      run: nix-build -A universal-canister
 
     - if: matrix.os == 'ubuntu-latest'
       run: nix build -f default.nix --eval-store auto --store ssh-ng://eu.nixbuild.net --builders "" --max-jobs 2 --no-link --print-build-logs ic-hs
     - if: matrix.os == 'macos-latest'
-      run: nix-build-uncached -A ic-hs
+      run: nix-build -A ic-hs
 
     - if: matrix.os == 'ubuntu-latest'
       run: cp -r "$(nix-build -A ic-hs.doc)"/share/doc/*/html gh-page
@@ -63,12 +61,12 @@ jobs:
     - if: matrix.os == 'ubuntu-latest'
       run: nix build -f default.nix --eval-store auto --store ssh-ng://eu.nixbuild.net --builders "" --max-jobs 2 --no-link --print-build-logs check-generated
     - if: matrix.os == 'macos-latest'
-      run: nix-build-uncached -A check-generated
+      run: nix-build -A check-generated
 
     - if: matrix.os == 'ubuntu-latest'
       run: nix build -f default.nix --eval-store auto --store ssh-ng://eu.nixbuild.net --builders "" --max-jobs 2 --no-link --print-build-logs ic-ref-dist
     - if: matrix.os == 'macos-latest'
-      run: nix-build-uncached -A ic-ref-dist
+      run: nix-build -A ic-ref-dist
 
     - if: matrix.os == 'ubuntu-latest'
       run: nix build -f default.nix --eval-store auto --store ssh-ng://eu.nixbuild.net --builders "" --max-jobs 2 --no-link --print-build-logs ic-ref-test
@@ -76,12 +74,12 @@ jobs:
     - if: matrix.os == 'ubuntu-latest'
       run: nix build -f default.nix --eval-store auto --store ssh-ng://eu.nixbuild.net --builders "" --max-jobs 2 --no-link --print-build-logs ic-hs-shell
     - if: matrix.os == 'macos-latest'
-      run: nix-build-uncached -A ic-hs-shell
+      run: nix-build -A ic-hs-shell
 
     - if: matrix.os == 'ubuntu-latest'
       run: nix build -f default.nix --eval-store auto --store ssh-ng://eu.nixbuild.net --builders "" --max-jobs 2 --no-link --print-build-logs license-check
     - if: matrix.os == 'macos-latest'
-      run: nix-build-uncached -A license-check
+      run: nix-build -A license-check
 
   release:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/default.nix
+++ b/default.nix
@@ -77,7 +77,8 @@ let
           -p '@executable_path/libs' \
           -i /usr/lib/system \
           -i ${nixpkgs.libiconv}/lib \
-          -i ${nixpkgs.darwin.Libsystem}/lib
+          -i ${nixpkgs.darwin.Libsystem}/lib \
+          --no-codesign
 
         # there are still plenty of nix store references
         # but they should not matter


### PR DESCRIPTION
The command `nix-build-uncached` does not seem to run the actual builds, so this PR replaces `nix-build-uncached` by `nix-build`.