### PR TITLE
increase ingress_expiry in reference test suite

### DIFF
--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -322,11 +322,11 @@ addNonce = addIfNotThere "nonce" $
 getRand8Bytes :: IO BS.ByteString
 getRand8Bytes = BS.pack <$> replicateM 8 randomIO
 
--- Adds expiry 1 minute
+-- Adds expiry 2 minutes
 addExpiry :: GenR -> IO GenR
 addExpiry = addIfNotThere "ingress_expiry" $ do
     t <- getPOSIXTime
-    return $ GNat $ round ((t + 60) * 1000_000_000)
+    return $ GNat $ round ((t + 60 * 2) * 1000_000_000)
 
 envelope :: SecretKey -> GenR -> IO GenR
 envelope sk = delegationEnv sk []

--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -322,11 +322,11 @@ addNonce = addIfNotThere "nonce" $
 getRand8Bytes :: IO BS.ByteString
 getRand8Bytes = BS.pack <$> replicateM 8 randomIO
 
--- Adds expiry 2 minutes
+-- Adds expiry 5 minutes
 addExpiry :: GenR -> IO GenR
 addExpiry = addIfNotThere "ingress_expiry" $ do
     t <- getPOSIXTime
-    return $ GNat $ round ((t + 60 * 2) * 1000_000_000)
+    return $ GNat $ round ((t + 60 * 5) * 1000_000_000)
 
 envelope :: SecretKey -> GenR -> IO GenR
 envelope sk = delegationEnv sk []


### PR DESCRIPTION
This MR increases `ingress_expiry` in the reference test suite and thus should help with test flakiness due to errors of the form
```
2023-05-17 09:40:36.544 INFO[test:StdOut]         src/IC/Test/Spec.hs:2424:
2023-05-17 09:40:36.544 INFO[test:StdOut]         Status 400 is not 2xx
2023-05-17 09:40:36.544 INFO[test:StdOut]         Specified ingress_expiry not within expected range:
2023-05-17 09:40:36.544 INFO[test:StdOut]         Minimum allowed expiry: 2023-05-17 09:40:36.454146577 UTC
2023-05-17 09:40:36.544 INFO[test:StdOut]         Maximum allowed expiry: 2023-05-17 09:46:06.454146577 UTC
2023-05-17 09:40:36.544 INFO[test:StdOut]         Provided expiry:        2023-05-17 09:40:34.111518055 UTC
2023-05-17 09:40:36.544 INFO[test:StdOut]         Local replica time:     2023-05-17 09:40:36.454147729 UTC
```