### PR TITLE
sync universal-canister with IC repo

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,9 @@ let nixpkgs = import ./nix { inherit system; }; in
 let stdenv = nixpkgs.stdenv; in
 let subpath = nixpkgs.subpath; in
 
-let naersk = nixpkgs.callPackage nixpkgs.sources.naersk { rustc = nixpkgs.rustc-wasm; }; in
+let naersk = nixpkgs.callPackage nixpkgs.sources.naersk {
+    inherit (nixpkgs.rustPackages) cargo rustc;
+}; in
 let universal-canister = (naersk.buildPackage rec {
     name = "universal-canister";
     src = subpath ./universal-canister;
@@ -151,7 +153,7 @@ in
 
   let httpbin = (naersk.buildPackage rec {
     name = "httpbin-rs";
-    root = ./httpbin-rs;
+    root = subpath ./httpbin-rs;
     doCheck = false;
     release = true;
     nativeBuildInputs = with nixpkgs; [ pkg-config ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -29,19 +29,21 @@ let
 
           subpath = import ./gitSource.nix;
 
-          # nixpkgs's rustc does not inclue the wasm32-unknown-unknown target, so
-          # lets add it here. With this we can build the universal canister with stock
-          # nixpkgs + naersk, in particular no dependency on internal repositories.
-          # But rename this so that we do not rebuilt unrelated tools written in rust.
-          rustc-wasm = super.rustc.overrideAttrs (old: {
-            configureFlags = self.lib.lists.forEach old.configureFlags (flag:
-              if self.lib.strings.hasPrefix "--target=" flag
-              then flag + ",wasm32-unknown-unknown"
-              else flag) ++ [
-                # https://github.com/rust-lang/rust/issues/76526
-                "--set=build.docs=false"
-              ];
-          });
+          rustPackages = self.rustPackages_1_66 // {
+            # nixpkgs's rustc does not inclue the wasm32-unknown-unknown target, so
+            # lets add it here. With this we can build the universal canister with stock
+            # nixpkgs + naersk, in particular no dependency on internal repositories.
+            # But rename this so that we do not rebuilt unrelated tools written in rust.
+            rustc = self.rustPackages_1_66.rustc.overrideAttrs (old: {
+              configureFlags = self.lib.lists.forEach old.configureFlags (flag:
+                if self.lib.strings.hasPrefix "--target=" flag
+                then flag + ",wasm32-unknown-unknown"
+                else flag) ++ [
+                  # https://github.com/rust-lang/rust/issues/76526
+                  "--set=build.docs=false"
+                ];
+            });
+          };
 
           all-cabal-hashes = self.fetchurl {
             url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/35f4996e28c5ba20a3a633346f21abe2072afeb6.tar.gz";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -40,6 +40,7 @@ let
                 then flag + ",wasm32-unknown-unknown"
                 else flag) ++ [
                   # https://github.com/rust-lang/rust/issues/76526
+                  # fixed in Rust 1.69.0
                   "--set=build.docs=false"
                 ];
             });

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -30,10 +30,10 @@ let
           subpath = import ./gitSource.nix;
 
           rustPackages = self.rustPackages_1_66 // {
-            # nixpkgs's rustc does not inclue the wasm32-unknown-unknown target, so
-            # lets add it here. With this we can build the universal canister with stock
+            # nixpkgs's rustc does not include the wasm32-unknown-unknown target, so
+            # let's add it here. With this we can build the universal canister with stock
             # nixpkgs + naersk, in particular no dependency on internal repositories.
-            # But rename this so that we do not rebuilt unrelated tools written in rust.
+            # But rename this so that we do not rebuild unrelated tools written in rust.
             rustc = self.rustPackages_1_66.rustc.overrideAttrs (old: {
               configureFlags = self.lib.lists.forEach old.configureFlags (flag:
                 if self.lib.strings.hasPrefix "--target=" flag

--- a/universal-canister/src/main.rs
+++ b/universal-canister/src/main.rs
@@ -1,7 +1,6 @@
 use candid::{CandidType, Decode, Deserialize, Encode, Principal};
 use std::convert::TryInto;
-// Requires rust 1.66.0.
-// use std::hint::black_box;
+use std::hint::black_box;
 use universal_canister::Ops;
 
 mod api;
@@ -125,8 +124,7 @@ fn read_int64(ops_bytes: &mut OpsBytes) -> u64 {
 fn delay(value: u64) {
     for _ in 0..value {
         // Using `black_box` to make sure this no-op cycle is not removed by the compiler optimization.
-        // Requires rust 1.66.0.
-        // black_box(0);
+        black_box(0);
     }
 }
 


### PR DESCRIPTION
We bump Rust version to 1.66.1 and thus can fully sync universal-canister code with the IC repo.