### PR TITLE
decrease number of threads and request submission latency

### DIFF
--- a/src/IC/HTTP.hs
+++ b/src/IC/HTTP.hs
@@ -43,10 +43,14 @@ withApp subnets systemTaskPeriod backingFile action =
           lift getTimestamp >>= setAllTimesTo
           processSystemTasks
     loopIC :: Store IC -> IO ()
-    loopIC store = forever $ do
-        threadDelay 10000
-        modifyStore store aux
+    loopIC store = loop 1000
       where
+        loop :: Int -> IO ()
+        loop backoff = do
+          threadDelay backoff
+          b <- modifyStore store aux
+          if b then loop 1000
+          else loop (2 * backoff)
         aux = do
           lift getTimestamp >>= setAllTimesTo
           runStep

--- a/src/IC/HTTP.hs
+++ b/src/IC/HTTP.hs
@@ -44,7 +44,7 @@ withApp subnets systemTaskPeriod backingFile action =
           processSystemTasks
     loopIC :: Store IC -> IO ()
     loopIC store = forever $ do
-        threadDelay 2000
+        threadDelay 10000
         modifyStore store aux
       where
         aux = do
@@ -107,7 +107,7 @@ handle store req respond = case (requestMethod req, pathInfo req) of
       x <- modifyStore store $ do
         -- Here we make IC.Ref use “real time”
         lift getTimestamp >>= setAllTimesTo
-        processSystemTasks
+        --processSystemTasks
         a
       return x
 

--- a/src/IC/HTTP.hs
+++ b/src/IC/HTTP.hs
@@ -3,7 +3,7 @@
 module IC.HTTP where
 
 import Network.Wai
-import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (withAsync)
 import Network.HTTP.Types
 import qualified Data.Text as T
@@ -29,18 +29,27 @@ import IC.Utils
 
 withApp :: HasRefConfig => [SubnetConfig] -> Int -> Maybe FilePath -> (Application -> IO a) -> IO a
 withApp subnets systemTaskPeriod backingFile action =
-    withStore (initialIC subnets) backingFile $ \store -> 
-      withAsync (loopIC store) $ \_async -> 
+    withStore (initialIC subnets) backingFile $ \store ->
+      withAsync (loopSystemTasks store) $ \_async ->
+      withAsync (loopIC store) $ \_async ->
         action $ handle store
   where
-    loopIC :: Store IC -> IO ()
-    loopIC store = forever $ do
+    loopSystemTasks :: Store IC -> IO ()
+    loopSystemTasks store = forever $ do
         threadDelay systemTaskPeriod
         modifyStore store aux
       where
         aux = do
           lift getTimestamp >>= setAllTimesTo
           processSystemTasks
+    loopIC :: Store IC -> IO ()
+    loopIC store = forever $ do
+        threadDelay 2000
+        modifyStore store aux
+      where
+        aux = do
+          lift getTimestamp >>= setAllTimesTo
+          runStep
 
 handle :: HasRefConfig => Store IC -> Application
 handle store req respond = case (requestMethod req, pathInfo req) of
@@ -94,24 +103,17 @@ handle store req respond = case (requestMethod req, pathInfo req) of
   where
     runIC :: StateT IC IO a -> IO a
     runIC a = do
+      -- it is important that this thread returns, else warp is blocked somehow
       x <- modifyStore store $ do
         -- Here we make IC.Ref use “real time”
         lift getTimestamp >>= setAllTimesTo
         processSystemTasks
         a
-      -- begin processing in the background (it is important that
-      -- this thread returns, else warp is blocked somehow)
-      void $ forkIO loopIC
       return x
 
     -- Not atomic, reads most recent state
     peekIC :: StateT IC IO a -> IO a
     peekIC a = peekStore store >>= evalStateT a
-
-    loopIC :: IO ()
-    loopIC = modifyStore store runStep >>= \case
-        True -> loopIC
-        False -> return ()
 
     cbor status gr = respond $ responseBuilder
         status

--- a/src/IC/HTTP.hs
+++ b/src/IC/HTTP.hs
@@ -121,17 +121,20 @@ handle store req respond = case (requestMethod req, pathInfo req) of
 
     cbor status gr = respond $ responseBuilder
         status
-        [ (hContentType, "application/cbor") ]
+        [ (hContentType, "application/cbor"),
+          (hConnection, "close") ]
         (IC.HTTP.CBOR.encode gr)
 
     json status x = respond $ responseBuilder
         status
-        [ (hContentType, "application/json") ]
+        [ (hContentType, "application/json"),
+          (hConnection, "close") ]
         (JSON.fromEncoding $ JSON.toEncoding x)
 
     plain status x = respond $ responseBuilder
         status
-        [ (hContentType, "text/plain") ]
+        [ (hContentType, "text/plain"),
+          (hConnection, "close") ]
         x
 
     empty status = plain status mempty

--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -457,11 +457,13 @@ processMessage m = case m of
     ctxt <- getCallContext ctxt_id
     case origin ctxt of
       FromSystemTask -> error "Response from system task"
-      FromUser rid _ -> setReqStatus rid $ CallResponse $
-        -- NB: Here cycles disappear
-        case response of
-          Reject (rc, msg) -> canisterRejected (rc, msg, Nothing)
-          Reply blob -> Replied blob
+      FromUser rid _ -> do
+        setReqStatus rid $ CallResponse $
+          -- NB: Here cycles disappear
+          case response of
+            Reject (rc, msg) -> canisterRejected (rc, msg, Nothing)
+            Reply blob -> Replied blob
+        processSystemTasks
       FromCanister other_ctxt_id callback -> do
         -- Add refund to balance
         cid <- calleeOfCallID other_ctxt_id


### PR DESCRIPTION
**Changes**

This PR makes the following changes:
- run steps of the IC on a single thread with `yield` in between consecutive steps (given that every step needs to acquire a lock on the IC state, we don't gain much by having tight loops running steps of the IC on multiple threads)
- run system tasks (heartbeats and timers) whenever an ingress message result (reply/reject) is put into the certified state (as opposed to when the user submits the request which decreases the latency of the 202 HTTP response to the user request)

**Benchmarks**

base-line (a1b3f6706c33a40f1b7faa65a9652b3ddf39d1a6)
ic-ref-test: 410.51 s
ic-nns-init: 14.3 s

this PR
ic-ref-test: 409.86 s
ic-nns-init: 11.6 s