### PR TITLE
fix decoding compressed WASM modules during snapshotting

### DIFF
--- a/src/IC/Canister.hs
+++ b/src/IC/Canister.hs
@@ -7,6 +7,7 @@
 module IC.Canister
     ( WasmState
     , parseCanister
+    , decodeModule
     , CanisterModule(..)
     , InitFunc, UpdateFunc, QueryFunc
     , asUpdate

--- a/src/IC/Serialise.hs
+++ b/src/IC/Serialise.hs
@@ -113,7 +113,8 @@ instance Serialise CanisterContent where
         (wasm, insts, sm) <- decode
         can_mod <- either fail pure $ parseCanister wasm
         -- There is some duplication here
-        wasm_mod <- either fail pure $ W.parseModule wasm
+        decodedModule <- either fail pure $ decodeModule wasm
+        wasm_mod <- either fail pure $ W.parseModule decodedModule
         return $ CanisterContent
             { can_mod = can_mod
             , wasm_state = CanisterSnapshot


### PR DESCRIPTION
This PR fixes an issue with snapshotting IC states with canisters having compressed WASM modules. Currently, their compressed WASM modules are attempted to be parsed by Winter which fails because Winter expects the decompressed WASM. Hence, this PR decompresses all WASM modules decoded from a snapshot before parsing them with Winter.