### PR TITLE
bump canister version upon successful message execution and tighten tests

### DIFF
--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -96,6 +96,7 @@ library
   exposed-modules: IC.Test.Spec
   exposed-modules: IC.Test.Spec.HTTP
   exposed-modules: IC.Test.Spec.Timer
+  exposed-modules: IC.Test.Spec.CanisterVersion
   exposed-modules: IC.Test.Spec.TECDSA
   exposed-modules: IC.Test.Spec.Utils
   exposed-modules: IC.Test.StableMemory

--- a/src/IC/Canister.hs
+++ b/src/IC/Canister.hs
@@ -48,6 +48,8 @@ type IsPublic = Bool
 data CanisterModule = CanisterModule
   { raw_wasm :: Blob
   , raw_wasm_hash :: Blob -- just caching, it’s worth it
+  , exports_heartbeat :: Bool
+  , exports_global_timer :: Bool
   , init_method :: InitFunc
   , update_methods :: MethodName ↦ (EntityId -> Env -> NeedsToRespond -> Cycles -> Blob -> UpdateFunc)
   , query_methods :: MethodName ↦ (EntityId -> Env -> Blob -> QueryFunc)
@@ -94,6 +96,8 @@ parseCanister bytes = do
   return $ CanisterModule
     { raw_wasm = bytes
     , raw_wasm_hash = sha256 bytes
+    , exports_heartbeat = "canister_heartbeat" `elem` exportedFunctions wasm_mod
+    , exports_global_timer = "canister_global_timer" `elem` exportedFunctions wasm_mod
     , init_method = \caller env dat ->
           case instantiate wasm_mod of
             Trap err -> Trap err

--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -443,7 +443,7 @@ processMessage m = case m of
       wasm_state <- getCanisterState callee
       can_mod <- getCanisterMod callee
       env <- canisterEnv callee
-      invokeEntry ctxt_id wasm_state can_mod env entry >>= \case
+      invokeEntry ctxt_id callee wasm_state can_mod env entry >>= \case
         Trap msg -> do
           -- Eventually update cycle balance here
           rememberTrap ctxt_id msg
@@ -524,16 +524,21 @@ actuallyStopCanister canister_id =
 
  
 invokeEntry :: ICM m =>
-    CallId -> WasmState -> CanisterModule -> Env -> EntryPoint ->
+    CallId -> CanisterId -> WasmState -> CanisterModule -> Env -> EntryPoint ->
     m (TrapOr (WasmState, UpdateResult))
-invokeEntry ctxt_id wasm_state can_mod env entry = do
+invokeEntry ctxt_id canister_id wasm_state can_mod env entry = do
     needs_to_respond <- needsToRespondCallID ctxt_id
     available <- getCallContextCycles ctxt_id
     case entry of
       Public method dat -> do
         caller <- callerOfCallID ctxt_id
         case lookupUpdate method can_mod of
-          Just f -> return $ f caller env needs_to_respond available dat wasm_state
+          Just f ->
+            case f caller env needs_to_respond available dat wasm_state of
+              Trap err -> return $ Trap err
+              Return x -> do
+                bumpCanisterVersion canister_id
+                return $ Return x
           Nothing -> do
             let reject = Reject (RC_DESTINATION_INVALID, "method does not exist: " ++ method)
             return $ Return (wasm_state, (noCallActions { ca_response = Just reject}, noCanisterActions))
@@ -541,24 +546,32 @@ invokeEntry ctxt_id wasm_state can_mod env entry = do
         case callbacks can_mod cb env needs_to_respond available r refund wasm_state of
             Trap err -> do
               rememberTrap ctxt_id err
-              return $
-                  case cleanup_callback cb of
-                      Just closure -> case cleanup can_mod closure env wasm_state of
-                          Trap err' -> Trap err'
-                          Return (wasm_state', ()) ->
-                              Return (wasm_state', (noCallActions, noCanisterActions))
-                      Nothing -> Trap err
-            Return (wasm_state, actions) -> return $ Return (wasm_state, actions)
-      Heartbeat -> return $ do
-        case heartbeat can_mod env wasm_state of
-            Trap _ -> Return (wasm_state, (noCallActions, noCanisterActions))
-            Return (wasm_state, (calls, actions)) ->
-                Return (wasm_state, (noCallActions { ca_new_calls = calls }, actions))
-      GlobalTimer -> return $ do
-        case canister_global_timer can_mod env wasm_state of
-            Trap _ -> Return (wasm_state, (noCallActions, noCanisterActions))
-            Return (wasm_state, (calls, actions)) ->
-                Return (wasm_state, (noCallActions { ca_new_calls = calls }, actions))
+              case cleanup_callback cb of
+                  Just closure -> case cleanup can_mod closure env wasm_state of
+                      Trap err' -> return $ Trap err'
+                      Return (wasm_state', ()) -> do
+                          bumpCanisterVersion canister_id
+                          return $ Return (wasm_state', (noCallActions, noCanisterActions))
+                  Nothing -> return $ Trap err
+            Return (wasm_state, actions) -> do
+                bumpCanisterVersion canister_id
+                return $ Return (wasm_state, actions)
+      Heartbeat ->
+        if exports_heartbeat can_mod then
+          case heartbeat can_mod env wasm_state of
+            Trap _ -> return $ Return (wasm_state, (noCallActions, noCanisterActions))
+            Return (wasm_state, (calls, actions)) -> do
+                bumpCanisterVersion canister_id
+                return $ Return (wasm_state, (noCallActions { ca_new_calls = calls }, actions))
+        else return $ Return (wasm_state, (noCallActions, noCanisterActions))
+      GlobalTimer ->
+        if exports_global_timer can_mod then do
+          case canister_global_timer can_mod env wasm_state of
+            Trap _ -> return $ Return (wasm_state, (noCallActions, noCanisterActions))
+            Return (wasm_state, (calls, actions)) -> do
+                bumpCanisterVersion canister_id
+                return $ Return (wasm_state, (noCallActions { ca_new_calls = calls }, actions))
+        else return $ Return (wasm_state, (noCallActions, noCanisterActions))
   where
     lookupUpdate method can_mod
         | Just f <- M.lookup method (update_methods can_mod) = Just f

--- a/src/IC/Test/Spec/CanisterVersion.hs
+++ b/src/IC/Test/Spec/CanisterVersion.hs
@@ -171,7 +171,7 @@ canister_version_tests ecid =
       ctr2 @?= 1
     , simpleTestCase "after failed install" ecid $ \cid -> do
       ctr1 <- query cid (replyData canister_version) >>= asWord64
-      _ <- ic_install' ic00 (enum #install) cid "" ""
+      ic_install' ic00 (enum #install) cid "" "" >>= isReject [5]
       ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
@@ -183,7 +183,7 @@ canister_version_tests ecid =
       ctr @?= 1
     , simpleTestCase "after failed reinstall" ecid $ \cid -> do
       ctr1 <- query cid (replyData canister_version) >>= asWord64
-      _ <- ic_install' ic00 (enum #reinstall) cid "" ""
+      ic_install' ic00 (enum #reinstall) cid "" "" >>= isReject [5]
       ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
@@ -195,7 +195,7 @@ canister_version_tests ecid =
       ctr2 @?= 1
     , simpleTestCase "after failed upgrade" ecid $ \cid -> do
       ctr1 <- query cid (replyData canister_version) >>= asWord64
-      _ <- ic_install' ic00 (enum #upgrade) cid "" ""
+      ic_install' ic00 (enum #upgrade) cid "" "" >>= isReject [5]
       ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
@@ -274,13 +274,13 @@ canister_version_tests ecid =
       ctr2 @?= 2 --update was executed, but callback and cleanup both trapped
     , simpleTestCase "after failed uninstall" ecid $ \cid -> do
       ctr1 <- query cid (replyData canister_version) >>= asWord64
-      _ <- ic_uninstall'' otherUser cid
+      ic_uninstall'' otherUser cid >>= isErrOrReject [5]
       ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1
     , simpleTestCase "after failed change of settings" ecid $ \cid -> do
       ctr1 <- query cid (replyData canister_version) >>= asWord64
-      _ <- ic_update_settings' ic00 cid (#freezing_threshold .== 2^(70::Int))
+      ic_update_settings' ic00 cid (#freezing_threshold .== 2^(70::Int)) >>= isReject [5]
       ctr2 <- query cid (replyData canister_version) >>= asWord64
       ctr1 @?= 1
       ctr2 @?= 1

--- a/src/IC/Test/Spec/CanisterVersion.hs
+++ b/src/IC/Test/Spec/CanisterVersion.hs
@@ -1,0 +1,287 @@
+{- |
+
+This module contains a test suite for the Internet Computer
+
+-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module IC.Test.Spec.CanisterVersion (canister_version_tests) where
+
+import Data.ByteString.Builder
+import Test.Tasty
+import Test.Tasty.HUnit
+import Data.Row as R
+
+import IC.Test.Universal
+import IC.Test.Agent
+import IC.Test.Agent.UnsafeCalls
+import IC.Test.Agent.SafeCalls
+import IC.Test.Agent.UserCalls
+import IC.Test.Spec.Utils
+
+-- * The test suite
+
+canister_version_tests :: HasAgentConfig => Blob -> [TestTree]
+canister_version_tests ecid =
+    let canister_version = i64tob canisterVersion in
+    let no_heartbeat = onHeartbeat (callback $ trap $ bytes "") in
+    let simpleTestCase name ecid act = testCase name $ install ecid no_heartbeat >>= act in
+    let get_global cid = query cid $ replyData getGlobal in
+    let blob = toLazyByteString . word64LE . fromIntegral in
+    let wait_for_global cid n = waitFor $ (blob n ==) <$> get_global cid in
+    [ simpleTestCase "in query" ecid $ \cid -> do
+      ctr <- query cid (replyData canister_version) >>= asWord64
+      ctr @?= 1
+      ctr <- query cid (replyData canister_version) >>= asWord64
+      ctr @?= 1
+      ctr <- query cid (replyData canister_version) >>= asWord64
+      ctr @?= 1
+    , simpleTestCase "in update" ecid $ \cid -> do
+      ctr <- call cid (replyData canister_version) >>= asWord64
+      ctr @?= 1
+      ctr <- call cid (replyData canister_version) >>= asWord64
+      ctr @?= 2
+      ctr <- call cid (replyData canister_version) >>= asWord64
+      ctr @?= 3
+    , testCase "in install" $ do
+      cid <- install ecid $ no_heartbeat >>> setGlobal canister_version
+      ctr1 <- query cid (replyData getGlobal) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , simpleTestCase "in reinstall" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      _ <- reinstall cid $ no_heartbeat >>> setGlobal canister_version
+      ctr2 <- query cid (replyData getGlobal) >>= asWord64
+      ctr3 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2
+      ctr3 @?= 2
+    , testCase "in pre_upgrade" $ do
+      cid <- install ecid $
+        no_heartbeat >>>
+        ignore (stableGrow (int 1)) >>>
+        onPreUpgrade (callback $ stableWrite (int 0) canister_version)
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      upgrade cid no_heartbeat
+      ctr2 <- query cid (replyData (stableRead (int 0) (int 8))) >>= asWord64
+      ctr3 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+      ctr3 @?= 2
+    , simpleTestCase "in post_upgrade" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      upgrade cid $ no_heartbeat >>> setGlobal canister_version
+      ctr2 <- query cid (replyData getGlobal) >>= asWord64
+      ctr3 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2
+      ctr3 @?= 2
+    , testCase "in heartbeat" $ do
+      cid <- install ecid $
+        onHeartbeat (callback $ trapIfNeq canister_version (i64tob $ int64 1) "" >>> setGlobal canister_version)
+      wait_for_global cid (1::Int)
+      ctr1 <- query cid (replyData getGlobal) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2
+    , testCase "in global timer" $ do
+      cid <- install ecid $
+        no_heartbeat >>>
+        onGlobalTimer (callback $ setGlobal canister_version) >>>
+        ignore (apiGlobalTimerSet $ int64 1)
+      wait_for_global cid (1::Int)
+      ctr1 <- query cid (replyData getGlobal) >>= asWord64
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2
+    , simpleTestCase "in reply callback" ecid $ \cid -> do
+      cid2 <- install ecid noop
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      ctr2 <- call cid (inter_call cid2 "update" defArgs {
+          on_reply = replyData canister_version,
+          on_reject = trap $ bytes "" --make test fail if reject callback was executed
+        }) >>= asWord64
+      ctr3 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2
+      ctr3 @?= 3
+    , simpleTestCase "in reject callback" ecid $ \cid -> do
+      cid2 <- install ecid noop
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      ctr2 <- call cid (inter_call cid2 "update" defArgs {
+          on_reply = trap $ bytes "", --make test fail if reply callback was executed
+          on_reject = replyData canister_version,
+          other_side = trap $ bytes "" --other side traps which triggers reject callback
+        }) >>= asWord64
+      ctr3 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2
+      ctr3 @?= 3
+    , simpleTestCase "in cleanup" ecid $ \cid -> do
+      cid2 <- install ecid noop
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      call' cid (inter_call cid2 "update" defArgs {
+          on_reply = trap $ bytes "",
+          on_reject = trap $ bytes "", --make test fail if reject callback was executed
+          on_cleanup = Just $ (setGlobal canister_version)
+        }) >>= isReject [5]
+      ctr2 <- query cid (replyData getGlobal) >>= asWord64
+      ctr3 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2
+      ctr3 @?= 3
+    , simpleTestCase "after uninstall" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      ic_uninstall ic00 cid
+      installAt cid no_heartbeat
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 3 -- code uninstalled and installed since the last query
+    , simpleTestCase "after setting controllers" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      ic_set_controllers ic00 cid [otherUser]
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2
+    , simpleTestCase "after setting freezing threshold" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      ic_update_settings ic00 cid (#freezing_threshold .== 2^(20::Int))
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2
+    , simpleTestCase "after failed query" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      query' cid (trap "") >>= isReject [5]
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , simpleTestCase "after failed update" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      call' cid (trap "") >>= isReject [5]
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , simpleTestCase "after failed install" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      _ <- ic_install' ic00 (enum #install) cid "" ""
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , testCase "after failed init in install" $ do
+      cid <- create ecid
+      install' cid (trap $ bytes "") >>= isReject [5]
+      _ <- installAt cid $ no_heartbeat
+      ctr <- query cid (replyData canister_version) >>= asWord64
+      ctr @?= 1
+    , simpleTestCase "after failed reinstall" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      _ <- ic_install' ic00 (enum #reinstall) cid "" ""
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , simpleTestCase "after failed init in reinstall" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      reinstall' cid (trap $ bytes "") >>= isReject [5]
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , simpleTestCase "after failed upgrade" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      _ <- ic_install' ic00 (enum #upgrade) cid "" ""
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , testCase "after failed pre_upgrade" $ do
+      cid <- install ecid $
+        no_heartbeat >>>
+        onPreUpgrade (callback $ trap $ bytes "")
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      upgrade' cid no_heartbeat >>= isReject [5]
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , simpleTestCase "after failed post_upgrade" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      upgrade' cid (trap $ bytes "") >>= isReject [5]
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , testCase "after failed heartbeat" $ do
+      cid <- install ecid $ onHeartbeat (callback $ trap $ bytes "")
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      -- The spec currently gives no guarantee about when or how frequent heartbeats are executed.
+      -- But all implementations have the property: if update call B is submitted after call A is completed,
+      -- then a heartbeat runs before the execution of B.
+      -- We use this here to make sure that heartbeats have been attempted:
+      call_ cid reply
+      call_ cid reply
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 3 --only two update calls have been executed, but no heartbeats
+    , testCase "after failed global timer" $ do
+      cid <- install ecid $ no_heartbeat >>>
+        onGlobalTimer (callback $ trap $ bytes "") >>>
+        ignore (apiGlobalTimerSet $ int64 1)
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      -- The spec currently gives no guarantee about when or how frequent global timers are executed.
+      -- But all implementations have the property: if update call B is submitted after call A is completed,
+      -- then a global timer runs before the execution of B.
+      -- We use this here to make sure that global timers have been attempted:
+      call_ cid reply
+      call_ cid reply
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 3 --only two update calls have been executed, but no global timers
+    , simpleTestCase "after failed reply callback" ecid $ \cid -> do
+      cid2 <- install ecid noop
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      call' cid (inter_call cid2 "update" defArgs {
+          on_reply = trap $ bytes "",
+          on_reject = replyData "" --make test fail if reject callback was executed
+        }) >>= isReject [5]
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2 --update was executed, but callback trapped and no cleanup was provided
+    , simpleTestCase "after failed reject callback" ecid $ \cid -> do
+      cid2 <- install ecid noop
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      call' cid (inter_call cid2 "update" defArgs {
+          on_reply = replyData "", --make test fail if reply callback was executed
+          on_reject = trap $ bytes "",
+          other_side = trap $ bytes "" --other side traps which triggers reject callback
+        }) >>= isReject [5]
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2 --update was executed, but callback trapped and no cleanup was provided
+    , simpleTestCase "after failed cleanup" ecid $ \cid -> do
+      cid2 <- install ecid noop
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      call' cid (inter_call cid2 "update" defArgs {
+          on_reply = trap $ bytes "",
+          on_reject = replyData "", --make test fail if reject callback was executed
+          on_cleanup = Just $ trap $ bytes ""
+        }) >>= isReject [5]
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 2 --update was executed, but callback and cleanup both trapped
+    , simpleTestCase "after failed uninstall" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      _ <- ic_uninstall'' otherUser cid
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    , simpleTestCase "after failed change of settings" ecid $ \cid -> do
+      ctr1 <- query cid (replyData canister_version) >>= asWord64
+      _ <- ic_update_settings' ic00 cid (#freezing_threshold .== 2^(70::Int))
+      ctr2 <- query cid (replyData canister_version) >>= asWord64
+      ctr1 @?= 1
+      ctr2 @?= 1
+    ]

--- a/src/IC/Test/Spec/Timer.hs
+++ b/src/IC/Test/Spec/Timer.hs
@@ -17,30 +17,16 @@ module IC.Test.Spec.Timer (canister_timer_tests) where
 import Data.ByteString.Builder
 import Test.Tasty
 import Test.Tasty.HUnit
-import Control.Monad
 import Data.Row as R
 import Data.Time.Clock.POSIX
 import Codec.Candid (Principal(..))
 import qualified Codec.Candid as Candid
-import Control.Concurrent
-import System.Timeout
 
 import IC.Management (InstallMode)
 import IC.Test.Universal
 import IC.Test.Agent
 import IC.Test.Agent.UnsafeCalls
 import IC.Test.Spec.Utils
-
--- * Helpers
-
-waitFor :: HasAgentConfig => IO Bool -> IO ()
-waitFor act = do
-    result <- timeout (tc_timeout agentConfig * (10::Int) ^ (6::Int)) doActUntil
-    when (result == Nothing) $ assertFailure "Polling timed out"
-  where
-    doActUntil = do
-      stop <- act
-      unless stop (threadDelay 1000 *> doActUntil)
 
 -- * The test suite (see below for helper functions)
 


### PR DESCRIPTION
The replica implementation increments the canister version upon every successful message execution so let’s do the same in the reference implementation and tighten its test suite.