### PR TITLE
trim long blobs in json debug state

### DIFF
--- a/src/IC/Debug/JSON.hs
+++ b/src/IC/Debug/JSON.hs
@@ -37,6 +37,7 @@ import IC.Canister.Snapshot
 import IC.Canister
 import IC.Ref
 import IC.Crypto
+import IC.Hash
 
 customOptions :: Options
 customOptions = defaultOptions
@@ -48,7 +49,9 @@ instance ToJSON W.Value where
     toEncoding = genericToEncoding customOptions
 
 instance ToJSON BS.ByteString where
-    toJSON = String . H.encodeHex . BS.toStrict
+    toJSON x
+      | BS.length x <= 1000 = String $ H.encodeHex $ BS.toStrict x
+      | otherwise = String $ (H.encodeHex $ BS.toStrict $ BS.take 1000 x) <> "... (sha256: 0x" <> H.encodeHex (BS.toStrict $ sha256 x) <> ")"
 
 instance ToJSONKey BS.ByteString where
     toJSONKey = toJSONKeyText (H.encodeHex . BS.toStrict)

--- a/src/IC/Debug/JSON.hs
+++ b/src/IC/Debug/JSON.hs
@@ -51,7 +51,7 @@ instance ToJSON W.Value where
 instance ToJSON BS.ByteString where
     toJSON x
       | BS.length x <= 1000 = String $ H.encodeHex $ BS.toStrict x
-      | otherwise = String $ (H.encodeHex $ BS.toStrict $ BS.take 1000 x) <> "... (sha256: 0x" <> H.encodeHex (BS.toStrict $ sha256 x) <> ")"
+      | otherwise = String $ "too long for a debug print (sha256: 0x" <> H.encodeHex (BS.toStrict $ sha256 x) <> ")"
 
 instance ToJSONKey BS.ByteString where
     toJSONKey = toJSONKeyText (H.encodeHex . BS.toStrict)


### PR DESCRIPTION
The JSON debug state exposed at `http://localhost:<port>` is intended for manual inspection in a web browser and thus we should trim long blobs that slow down loading the JSON file in the web browser without facilitating human readability.