### PR TITLE
reproduce wasmtime-hs segfault

### DIFF
--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -173,11 +173,13 @@ library
   build-depends: uglymemo
   build-depends: unordered-containers
   build-depends: utf8-string
+  build-depends: unliftio
   build-depends: vector
   build-depends: wai
   build-depends: wai-cors
   build-depends: wai-extra
   build-depends: warp
+  build-depends: wasmtime
   build-depends: wide-word
   build-depends: winter
   build-depends: word8

--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -173,7 +173,6 @@ library
   build-depends: uglymemo
   build-depends: unordered-containers
   build-depends: utf8-string
-  build-depends: unliftio
   build-depends: vector
   build-depends: wai
   build-depends: wai-cors

--- a/nix/generate.nix
+++ b/nix/generate.nix
@@ -92,7 +92,7 @@ let
       pkgs.lib.flip pkgs.lib.mapAttrsToList packages (
         n: pkg: ''
           cp ${pkg}/default.nix $out/${n}.nix
-          echo '  ${n} = super.callPackage ./${n}.nix { };' >> $out/all.nix
+          echo '  ${n} = super.callPackage ./${n}.nix { ${pkgs.lib.optionalString (n == "ic-hs") "wasmtime = self.wasmtime-hs;"} };' >> $out/all.nix
         ''
       )
     ) + ''

--- a/nix/generate.nix
+++ b/nix/generate.nix
@@ -53,6 +53,12 @@ let
       extraCabal2nixOptions = "--no-check";
     };
 
+    wasmtime-hs = haskellSrc2nixWithDoc {
+      name = "wasmtime-hs";
+      src = pkgs.sources.wasmtime-hs;
+      src_subst = "pkgs.sources.wasmtime-hs";
+      extraCabal2nixOptions = "--no-check";
+    };
     winter = haskellSrc2nixWithDoc {
       name = "winter";
       src = pkgs.sources.winter;

--- a/nix/generated/all.nix
+++ b/nix/generated/all.nix
@@ -3,5 +3,6 @@ self: super: {
   http-client = super.callPackage ./http-client.nix { };
   ic-hs = super.callPackage ./ic-hs.nix { };
   leb128-cereal = super.callPackage ./leb128-cereal.nix { };
+  wasmtime-hs = super.callPackage ./wasmtime-hs.nix { };
   winter = super.callPackage ./winter.nix { };
 }

--- a/nix/generated/all.nix
+++ b/nix/generated/all.nix
@@ -1,7 +1,7 @@
 self: super: {
   candid = super.callPackage ./candid.nix { };
   http-client = super.callPackage ./http-client.nix { };
-  ic-hs = super.callPackage ./ic-hs.nix { };
+  ic-hs = super.callPackage ./ic-hs.nix { wasmtime = self.wasmtime-hs; };
   leb128-cereal = super.callPackage ./leb128-cereal.nix { };
   wasmtime-hs = super.callPackage ./wasmtime-hs.nix { };
   winter = super.callPackage ./winter.nix { };

--- a/nix/generated/ic-hs.nix
+++ b/nix/generated/ic-hs.nix
@@ -69,7 +69,7 @@
 , wai-cors
 , wai-extra
 , warp
-, wasmtime-hs
+, wasmtime
 , wide-word
 , winter
 , word8
@@ -150,7 +150,7 @@ mkDerivation {
     wai-cors
     wai-extra
     warp
-    wasmtime-hs
+    wasmtime
     wide-word
     winter
     word8

--- a/nix/generated/ic-hs.nix
+++ b/nix/generated/ic-hs.nix
@@ -69,6 +69,7 @@
 , wai-cors
 , wai-extra
 , warp
+, wasmtime-hs
 , wide-word
 , winter
 , word8
@@ -149,6 +150,7 @@ mkDerivation {
     wai-cors
     wai-extra
     warp
+    wasmtime-hs
     wide-word
     winter
     word8

--- a/nix/generated/wasmtime-hs.nix
+++ b/nix/generated/wasmtime-hs.nix
@@ -1,0 +1,46 @@
+# THIS IS AN AUTOMATICALLY GENERATED FILE. DO NOT EDIT MANUALLY!
+# See ./nix/generate.nix for instructions.
+
+{ mkDerivation
+, pkgs
+, base
+, bindings-DSL
+, bytestring
+, lib
+, primitive
+, tasty
+, tasty-hunit
+, transformers
+, vector
+, wasmtime
+, wide-word
+}:
+mkDerivation {
+  pname = "wasmtime";
+  version = "0.0.0.0";
+  src = pkgs.sources.wasmtime-hs;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    base
+    bindings-DSL
+    bytestring
+    primitive
+    tasty
+    tasty-hunit
+    transformers
+    vector
+    wide-word
+  ];
+  librarySystemDepends = [ wasmtime ];
+  testHaskellDepends = [
+    base
+    bytestring
+    primitive
+    tasty
+    tasty-hunit
+  ];
+  doCheck = false;
+  homepage = "https://github.com/dfinity/wasmtime-hs";
+  description = "Haskell bindings to the wasmtime WASM engine";
+  license = lib.licenses.bsd2;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -64,10 +64,10 @@
         "homepage": "https://github.com/dfinity/wasmtime-hs",
         "owner": "dfinity",
         "repo": "wasmtime-hs",
-        "rev": "99e09198620626555ee68c2e41b62eaf9419f9ff",
-        "sha256": "sha256-/RJLjIsrhFCDX0NxNATvUZLnMRSFngvaShFYZlMj5ok=",
+        "rev": "646ca979d5f5c5f87d30ace70cb4541c50e4fbb1",
+        "sha256": "0hgqx8gq0nzvlnl1wd6mi12lcrjly1x5sxpddhv4fxf864h7k0ha",
         "type": "tarball",
-        "url": "https://github.com/dfinity/wasmtime-hs/archive/99e09198620626555ee68c2e41b62eaf9419f9ff.tar.gz",
+        "url": "https://github.com/dfinity/wasmtime-hs/archive/646ca979d5f5c5f87d30ace70cb4541c50e4fbb1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "winter": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -57,6 +57,19 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/652af6eb88e1bc633bc6dc44827519f6e7284dbb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "wasmtime-hs": {
+        "branch": "master",
+        "builtin": false,
+        "description": "Haskell binding to wasmtime",
+        "homepage": "https://github.com/dfinity/wasmtime-hs",
+        "owner": "dfinity",
+        "repo": "wasmtime-hs",
+        "rev": "99e09198620626555ee68c2e41b62eaf9419f9ff",
+        "sha256": "sha256-/RJLjIsrhFCDX0NxNATvUZLnMRSFngvaShFYZlMj5ok=",
+        "type": "tarball",
+        "url": "https://github.com/dfinity/wasmtime-hs/archive/99e09198620626555ee68c2e41b62eaf9419f9ff.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "winter": {
         "branch": "master",
         "builtin": false,

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -64,10 +64,10 @@
         "homepage": "https://github.com/dfinity/wasmtime-hs",
         "owner": "dfinity",
         "repo": "wasmtime-hs",
-        "rev": "646ca979d5f5c5f87d30ace70cb4541c50e4fbb1",
-        "sha256": "0hgqx8gq0nzvlnl1wd6mi12lcrjly1x5sxpddhv4fxf864h7k0ha",
+        "rev": "cb9a2fc5076cdcb6e388df1bfeb95104dcc9cb95",
+        "sha256": "sha256-dVyZXvTe6r2cDXkVyOi/bcFAvYFkhBJgR+JoL+qHUwQ=",
         "type": "tarball",
-        "url": "https://github.com/dfinity/wasmtime-hs/archive/646ca979d5f5c5f87d30ace70cb4541c50e4fbb1.tar.gz",
+        "url": "https://github.com/dfinity/wasmtime-hs/archive/cb9a2fc5076cdcb6e388df1bfeb95104dcc9cb95.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "winter": {

--- a/src/IC/Canister.hs
+++ b/src/IC/Canister.hs
@@ -79,9 +79,6 @@ decodeModule bytes =
     asmMagic = asBytes [0x00, 0x61, 0x73, 0x6d]
     gzipMagic = asBytes [0x1f, 0x8b, 0x08]
 
-msg_reply :: IO (Either Trap ())
-msg_reply = return $ Right ()
-
 parseCanister :: Blob -> Either String CanisterModule
 parseCanister bytes = do
   decodedModule <- decodeModule bytes
@@ -112,10 +109,7 @@ parseCanister bytes = do
                             Left err -> putStrLn (show err) >> error ""
                             Right r -> return r
           -- the following crashes
-          f <- newFunc ctx msg_reply
-          r <- newInstance ctx myModule (Vec.fromList [toExtern f])
-          -- the following "hangs" (never prints "done")
-          --r <- newInstance ctx myModule (Vec.fromList [])
+          r <- newInstance ctx myModule (Vec.fromList [])
           -- end
           putStrLn "done"
           void $ case r of

--- a/src/IC/Canister.hs
+++ b/src/IC/Canister.hs
@@ -108,7 +108,7 @@ parseCanister bytes = do
           engine <- newEngine
           store <- newStore engine
           ctx <- storeContext store
-          myModule <- case newModule engine (unsafeFromByteString $ BS.toStrict decodedModule) of
+          myModule <- case newModule engine (unsafeWasmFromBytes $ BS.toStrict decodedModule) of
                             Left err -> putStrLn (show err) >> error ""
                             Right r -> return r
           -- the following crashes

--- a/src/IC/Ref/Management.hs
+++ b/src/IC/Ref/Management.hs
@@ -218,7 +218,7 @@ icInstallCode caller r = do
       reinstall = do
         env <- canisterEnv canister_id
         let env1 = env { env_canister_version = env_canister_version env + 1, env_global_timer = 0 }
-        (wasm_state, ca) <- return (init_method new_can_mod caller env1 arg)
+        (wasm_state, ca) <- liftIO (init_method new_can_mod caller env1 arg)
           `onTrap` (\msg -> reject RC_CANISTER_ERROR ("Initialization trapped: " ++ msg) (Just EC_CANISTER_TRAPPED))
         setCanisterContent canister_id $ CanisterContent
             { can_mod = new_can_mod


### PR DESCRIPTION
Steps to reproduce:

1. Store this minimal WASM to a file:
```
$ echo -e "00000000  00 61 73 6d 01 00 00 00                           |.asm....|\n00000008" | xxd -r > e.wasm
$ hexdump -C e.wasm
00000000  00 61 73 6d 01 00 00 00                           |.asm....|
00000008
```
create an empty `counter.did` file
```
$ touch counter.did
```
and create a `dfx.json` file with the following content:
```
$ cat dfx.json
{
  "canisters": {
    "counter": {
      "type": "custom",
      "build": "",
      "wasm": "",
      "candid": "counter.did"
    }
  }
}
```

2. Run `ic-ref`:
```
$ cabal run ic-ref -- --listen-port 8080
Starting ic-ref...
Running at http://127.0.0.1:8080/
```

3. Create and install a canister with the WASM from step 1:
```
$ rm -rf .dfx && dfx canister create counter --no-wallet && dfx canister install counter --wasm e.wasm
```
then we see the following output from `ic-ref`:
```
done
Segmentation fault (core dumped)
```