### PR TITLE
Further debugging on the wasmtime segfault

### DIFF
--- a/bin/segfault.hs
+++ b/bin/segfault.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main (main) where
+
+import Data.Word
+import Foreign.C.Types
+import Foreign.Marshal.Alloc (malloc, mallocBytes)
+import Foreign.Marshal.Array (pokeArray)
+import Foreign.Ptr (FunPtr, Ptr, nullFunPtr, nullPtr)
+import Foreign.Storable
+import System.IO (BufferMode (NoBuffering), hSetBuffering, stdout)
+
+data C'wasm_engine_t = C'wasm_engine_t
+
+data C'wasmtime_store_t = C'wasmtime_store_t
+
+data C'wasmtime_context_t = C'wasmtime_context_t
+
+data C'wasmtime_module_t = C'wasmtime_module_t
+
+data C'wasmtime_error_t = C'wasmtime_error_t
+
+data C'wasm_trap_t = C'wasm_trap_t
+
+data C'wasmtime_extern_t = C'wasmtime_extern_t
+
+type C'wasmtime_trap_code_t = Word8
+
+data C'wasmtime_instance = C'wasmtime_instance
+  { c'wasmtime_instance'store_id :: Word64,
+    c'wasmtime_instance'index :: CSize
+  }
+  deriving (Eq, Show)
+
+instance Storable C'wasmtime_instance where
+  sizeOf _ = 16
+  alignment _ = 8
+  peek _p = do
+    v0 <- peekByteOff _p 0
+    v1 <- peekByteOff _p 8
+    return $ C'wasmtime_instance v0 v1
+  poke _p (C'wasmtime_instance v0 v1) = do
+    pokeByteOff _p 0 v0
+    pokeByteOff _p 8 v1
+    return ()
+
+type C'wasmtime_instance_t = C'wasmtime_instance
+
+foreign import ccall unsafe "wasm_engine_new"
+  c'wasm_engine_new ::
+    IO (Ptr C'wasm_engine_t)
+
+foreign import ccall unsafe "wasmtime_store_new"
+  c'wasmtime_store_new ::
+    Ptr C'wasm_engine_t -> Ptr a -> FunPtr (Ptr a -> IO ()) -> IO (Ptr C'wasmtime_store_t)
+
+foreign import ccall unsafe "wasmtime_store_context"
+  c'wasmtime_store_context ::
+    Ptr C'wasmtime_store_t -> IO (Ptr C'wasmtime_context_t)
+
+foreign import ccall unsafe "wasmtime_module_new"
+  c'wasmtime_module_new ::
+    Ptr C'wasm_engine_t -> Ptr Word8 -> CSize -> Ptr (Ptr C'wasmtime_module_t) -> IO (Ptr C'wasmtime_error_t)
+
+foreign import ccall unsafe "wasmtime_instance_new"
+  c'wasmtime_instance_new ::
+    Ptr C'wasmtime_context_t -> Ptr C'wasmtime_module_t -> Ptr C'wasmtime_extern_t -> CSize -> Ptr C'wasmtime_instance_t -> Ptr (Ptr C'wasm_trap_t) -> IO (Ptr C'wasmtime_error_t)
+
+foreign import ccall unsafe "wasmtime_trap_code"
+  c'wasmtime_trap_code ::
+    Ptr C'wasm_trap_t -> Ptr C'wasmtime_trap_code_t -> IO Bool
+
+main :: IO ()
+main = do
+  hSetBuffering stdout NoBuffering
+
+  engine_ptr <- c'wasm_engine_new
+  wasmtime_store_ptr <- c'wasmtime_store_new engine_ptr nullPtr nullFunPtr
+  ctx_ptr <- c'wasmtime_store_context wasmtime_store_ptr
+  let wasm = [0, 97, 115, 109, 1, 0, 0, 0] :: [Word8]
+      -- wasm = [0, 97, 115, 109, 1, 0, 0, 0, 1, 6, 1, 96, 1, 127, 1, 127, 3, 2, 1, 0, 7, 13, 1, 9, 102, 105, 98, 111, 110, 97, 99, 99, 105, 0, 0, 10, 30, 1, 28, 0, 32, 0, 65, 2, 72, 4, 64, 32, 0, 15, 11, 32, 0, 65, 1, 107, 16, 0, 32, 0, 65, 2, 107, 16, 0, 106, 11] :: [Word8]
+      n = length wasm
+  p <- mallocBytes n
+  pokeArray p wasm
+
+  module_ptr_ptr <- malloc
+  error_ptr <-
+    c'wasmtime_module_new
+      engine_ptr
+      p
+      (fromIntegral n)
+      module_ptr_ptr
+
+  print ("c'wasmtime_module_new: error_ptr", error_ptr)
+
+  mod_ptr <- peek module_ptr_ptr
+
+  putStrLn "Creating Instance ..."
+  (inst_ptr :: Ptr C'wasmtime_instance_t) <- malloc
+  (trap_ptr_ptr :: Ptr (Ptr C'wasm_trap_t)) <- malloc
+
+  error_ptr <-
+    c'wasmtime_instance_new
+      ctx_ptr
+      mod_ptr
+      nullPtr
+      0
+      inst_ptr
+      trap_ptr_ptr
+
+  print ("c'wasmtime_instance_new: error_ptr", error_ptr)
+
+  putStrLn "done"
+
+  trap_ptr <- peek trap_ptr_ptr
+
+  putStrLn "after peek"
+
+  if trap_ptr == nullPtr
+    then do
+      error "TODO"
+    else do
+      putStrLn "Received trap:"
+      print trap_ptr
+
+      code_ptr <- malloc
+      isInstructionTrap <- c'wasmtime_trap_code trap_ptr code_ptr
+      if isInstructionTrap
+        then do
+          code <- peek code_ptr
+          print ("code", code)
+        else putStrLn "No instructrion trap"
+
+      error "TODO"
+
+  putStrLn "The impossible happened!"
+
+  error "another error!"

--- a/default.nix
+++ b/default.nix
@@ -292,6 +292,8 @@ rec {
         nixpkgs.cabal-install
         nixpkgs.ghcid
         haskellPackages.haskell-language-server
+        nixpkgs.gdb
+        nixpkgs.valgrind
       ];
     };
 }

--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -173,11 +173,13 @@ library
   build-depends: uglymemo
   build-depends: unordered-containers
   build-depends: utf8-string
+  build-depends: unliftio
   build-depends: vector
   build-depends: wai
   build-depends: wai-cors
   build-depends: wai-extra
   build-depends: warp
+  build-depends: wasmtime
   build-depends: wide-word
   build-depends: winter
   build-depends: word8

--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -178,7 +178,7 @@ library
   build-depends: wai-cors
   build-depends: wai-extra
   build-depends: warp
-  build-depends: wasmtime
+  -- build-depends: wasmtime
   build-depends: wide-word
   build-depends: winter
   build-depends: word8
@@ -186,6 +186,8 @@ library
   build-depends: x509-store
   build-depends: x509-validation
   build-depends: zlib
+
+  extra-libraries: wasmtime
 
 executable ic-ref
   import: ghc-flags
@@ -203,6 +205,18 @@ executable ic-ref
   build-depends: wai-extra
   build-depends: warp
   build-depends: x509-store
+
+executable segfault
+  import: ghc-flags
+  ghc-options: -rtsopts
+
+  hs-source-dirs: bin
+  main-is: segfault.hs
+
+  build-depends: base >=4.12 && <5
+
+  extra-libraries: wasmtime
+
 
 executable ic-ref-run
   import: ghc-flags

--- a/ic-hs.cabal
+++ b/ic-hs.cabal
@@ -173,7 +173,6 @@ library
   build-depends: uglymemo
   build-depends: unordered-containers
   build-depends: utf8-string
-  build-depends: unliftio
   build-depends: vector
   build-depends: wai
   build-depends: wai-cors

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -54,6 +54,10 @@ let
           # We override secp256k1 since the version in nixpkgs doesn't provide a
           # .a library needed for a static build of ic-hs.
           secp256k1 = super.callPackage ./secp256k1 {};
+
+          wasmtime = super.callPackage ./wasmtime.nix {
+            inherit (self.darwin.apple_sdk.frameworks) Security;
+          };
         })
       ];
     };

--- a/nix/generate.nix
+++ b/nix/generate.nix
@@ -92,7 +92,7 @@ let
       pkgs.lib.flip pkgs.lib.mapAttrsToList packages (
         n: pkg: ''
           cp ${pkg}/default.nix $out/${n}.nix
-          echo '  ${n} = super.callPackage ./${n}.nix { ${pkgs.lib.optionalString (n == "ic-hs") "wasmtime = self.wasmtime-hs;"} };' >> $out/all.nix
+          echo '  ${n} = super.callPackage ./${n}.nix { };' >> $out/all.nix
         ''
       )
     ) + ''

--- a/nix/generate.nix
+++ b/nix/generate.nix
@@ -92,7 +92,7 @@ let
       pkgs.lib.flip pkgs.lib.mapAttrsToList packages (
         n: pkg: ''
           cp ${pkg}/default.nix $out/${n}.nix
-          echo '  ${n} = super.callPackage ./${n}.nix { };' >> $out/all.nix
+          echo '  ${n} = super.callPackage ./${n}.nix { ${pkgs.lib.optionalString (n == "ic-hs") "wasmtime = self.wasmtime-hs;"} };' >> $out/all.nix
         ''
       )
     ) + ''

--- a/nix/generate.nix
+++ b/nix/generate.nix
@@ -53,6 +53,12 @@ let
       extraCabal2nixOptions = "--no-check";
     };
 
+    wasmtime-hs = haskellSrc2nixWithDoc {
+      name = "wasmtime-hs";
+      src = pkgs.sources.wasmtime-hs;
+      src_subst = "pkgs.sources.wasmtime-hs";
+      extraCabal2nixOptions = "--no-check";
+    };
     winter = haskellSrc2nixWithDoc {
       name = "winter";
       src = pkgs.sources.winter;

--- a/nix/generated/all.nix
+++ b/nix/generated/all.nix
@@ -1,7 +1,7 @@
 self: super: {
   candid = super.callPackage ./candid.nix { };
   http-client = super.callPackage ./http-client.nix { };
-  ic-hs = super.callPackage ./ic-hs.nix { wasmtime = self.wasmtime-hs; };
+  ic-hs = super.callPackage ./ic-hs.nix { };
   leb128-cereal = super.callPackage ./leb128-cereal.nix { };
   wasmtime-hs = super.callPackage ./wasmtime-hs.nix { };
   winter = super.callPackage ./winter.nix { };

--- a/nix/generated/all.nix
+++ b/nix/generated/all.nix
@@ -3,5 +3,6 @@ self: super: {
   http-client = super.callPackage ./http-client.nix { };
   ic-hs = super.callPackage ./ic-hs.nix { };
   leb128-cereal = super.callPackage ./leb128-cereal.nix { };
+  wasmtime-hs = super.callPackage ./wasmtime-hs.nix { };
   winter = super.callPackage ./winter.nix { };
 }

--- a/nix/generated/all.nix
+++ b/nix/generated/all.nix
@@ -1,7 +1,7 @@
 self: super: {
   candid = super.callPackage ./candid.nix { };
   http-client = super.callPackage ./http-client.nix { };
-  ic-hs = super.callPackage ./ic-hs.nix { };
+  ic-hs = super.callPackage ./ic-hs.nix { wasmtime = self.wasmtime-hs; };
   leb128-cereal = super.callPackage ./leb128-cereal.nix { };
   wasmtime-hs = super.callPackage ./wasmtime-hs.nix { };
   winter = super.callPackage ./winter.nix { };

--- a/nix/generated/ic-hs.nix
+++ b/nix/generated/ic-hs.nix
@@ -69,7 +69,7 @@
 , wai-cors
 , wai-extra
 , warp
-, wasmtime-hs
+, wasmtime
 , wide-word
 , winter
 , word8
@@ -150,7 +150,7 @@ mkDerivation {
     wai-cors
     wai-extra
     warp
-    wasmtime-hs
+    wasmtime
     wide-word
     winter
     word8

--- a/nix/generated/ic-hs.nix
+++ b/nix/generated/ic-hs.nix
@@ -150,7 +150,6 @@ mkDerivation {
     wai-cors
     wai-extra
     warp
-    wasmtime
     wide-word
     winter
     word8
@@ -159,6 +158,7 @@ mkDerivation {
     x509-validation
     zlib
   ];
+  librarySystemDepends = [ wasmtime ];
   executableHaskellDepends = [
     async
     base

--- a/nix/generated/ic-hs.nix
+++ b/nix/generated/ic-hs.nix
@@ -69,6 +69,7 @@
 , wai-cors
 , wai-extra
 , warp
+, wasmtime-hs
 , wide-word
 , winter
 , word8
@@ -149,6 +150,7 @@ mkDerivation {
     wai-cors
     wai-extra
     warp
+    wasmtime-hs
     wide-word
     winter
     word8

--- a/nix/generated/wasmtime-hs.nix
+++ b/nix/generated/wasmtime-hs.nix
@@ -1,0 +1,46 @@
+# THIS IS AN AUTOMATICALLY GENERATED FILE. DO NOT EDIT MANUALLY!
+# See ./nix/generate.nix for instructions.
+
+{ mkDerivation
+, pkgs
+, base
+, bindings-DSL
+, bytestring
+, lib
+, primitive
+, tasty
+, tasty-hunit
+, transformers
+, vector
+, wasmtime
+, wide-word
+}:
+mkDerivation {
+  pname = "wasmtime";
+  version = "0.0.0.0";
+  src = pkgs.sources.wasmtime-hs;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    base
+    bindings-DSL
+    bytestring
+    primitive
+    tasty
+    tasty-hunit
+    transformers
+    vector
+    wide-word
+  ];
+  librarySystemDepends = [ wasmtime ];
+  testHaskellDepends = [
+    base
+    bytestring
+    primitive
+    tasty
+    tasty-hunit
+  ];
+  doCheck = false;
+  homepage = "https://github.com/dfinity/wasmtime-hs";
+  description = "Haskell bindings to the wasmtime WASM engine";
+  license = lib.licenses.bsd2;
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -64,10 +64,10 @@
         "homepage": "https://github.com/dfinity/wasmtime-hs",
         "owner": "dfinity",
         "repo": "wasmtime-hs",
-        "rev": "99e09198620626555ee68c2e41b62eaf9419f9ff",
-        "sha256": "sha256-/RJLjIsrhFCDX0NxNATvUZLnMRSFngvaShFYZlMj5ok=",
+        "rev": "646ca979d5f5c5f87d30ace70cb4541c50e4fbb1",
+        "sha256": "0hgqx8gq0nzvlnl1wd6mi12lcrjly1x5sxpddhv4fxf864h7k0ha",
         "type": "tarball",
-        "url": "https://github.com/dfinity/wasmtime-hs/archive/99e09198620626555ee68c2e41b62eaf9419f9ff.tar.gz",
+        "url": "https://github.com/dfinity/wasmtime-hs/archive/646ca979d5f5c5f87d30ace70cb4541c50e4fbb1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "winter": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -57,6 +57,19 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/652af6eb88e1bc633bc6dc44827519f6e7284dbb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "wasmtime-hs": {
+        "branch": "master",
+        "builtin": false,
+        "description": "Haskell binding to wasmtime",
+        "homepage": "https://github.com/dfinity/wasmtime-hs",
+        "owner": "dfinity",
+        "repo": "wasmtime-hs",
+        "rev": "99e09198620626555ee68c2e41b62eaf9419f9ff",
+        "sha256": "sha256-/RJLjIsrhFCDX0NxNATvUZLnMRSFngvaShFYZlMj5ok=",
+        "type": "tarball",
+        "url": "https://github.com/dfinity/wasmtime-hs/archive/99e09198620626555ee68c2e41b62eaf9419f9ff.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "winter": {
         "branch": "master",
         "builtin": false,

--- a/nix/wasmtime.nix
+++ b/nix/wasmtime.nix
@@ -1,0 +1,47 @@
+{ rustPlatform, fetchFromGitHub, Security, lib, stdenv }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wasmtime";
+  version = "9.0.3";
+
+  src = /home/bas/d/wasmtime/wasmtime;
+
+  cargoHash = "sha256-XhZcqB0RNr6JHKatsNAa8hjcq7Srem+6/dwMUuxerLg=";
+
+  cargoBuildFlags = [ "--package" "wasmtime-cli" "--package" "wasmtime-c-api" ];
+
+  outputs = [ "out" "dev" ];
+
+  buildInputs = lib.optional stdenv.isDarwin Security;
+
+  # SIMD tests are only executed on platforms that support all
+  # required processor features (e.g. SSE3, SSSE3 and SSE4.1 on x86_64):
+  # https://github.com/bytecodealliance/wasmtime/blob/v9.0.0/cranelift/codegen/src/isa/x64/mod.rs#L220
+  doCheck = with stdenv.buildPlatform; (isx86_64 -> sse3Support && ssse3Support && sse4_1Support);
+  cargoTestFlags = ["--package" "wasmtime-runtime"];
+
+  postInstall = ''
+    # move libs from out to dev
+    install -d -m 0755 $dev/lib
+    install -m 0644 ''${!outputLib}/lib/* $dev/lib
+    rm -r ''${!outputLib}/lib
+
+    install -d -m0755 $dev/include/wasmtime
+    install -m0644 $src/crates/c-api/include/*.h $dev/include
+    install -m0644 $src/crates/c-api/include/wasmtime/*.h $dev/include/wasmtime
+    install -m0644 $src/crates/c-api/wasm-c-api/include/* $dev/include
+  '' + lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id \
+      $dev/lib/libwasmtime.dylib \
+      $dev/lib/libwasmtime.dylib
+  '';
+
+  meta = with lib; {
+    description =
+      "Standalone JIT-style runtime for WebAssembly, using Cranelift";
+    homepage = "https://github.com/bytecodealliance/wasmtime";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ereslibre matthewbauer ];
+    platforms = platforms.unix;
+  };
+}

--- a/src/IC/Canister.hs
+++ b/src/IC/Canister.hs
@@ -79,9 +79,6 @@ decodeModule bytes =
     asmMagic = asBytes [0x00, 0x61, 0x73, 0x6d]
     gzipMagic = asBytes [0x1f, 0x8b, 0x08]
 
-msg_reply :: IO (Either Trap ())
-msg_reply = return $ Right ()
-
 parseCanister :: Blob -> Either String CanisterModule
 parseCanister bytes = do
   decodedModule <- decodeModule bytes
@@ -112,10 +109,7 @@ parseCanister bytes = do
                             Left err -> putStrLn (show err) >> error ""
                             Right r -> return r
           -- the following crashes
-          f <- newFunc ctx msg_reply
-          r <- newInstance ctx myModule (Vec.fromList [toExtern f])
-          -- the following "hangs" (never prints "done")
-          --r <- newInstance ctx myModule (Vec.fromList [])
+          r <- newInstance ctx myModule (Vec.fromList [])
           -- end
           putStrLn "done"
           void $ case r of

--- a/src/IC/Canister.hs
+++ b/src/IC/Canister.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module IC.Canister
     ( WasmState
@@ -17,6 +19,7 @@ module IC.Canister
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy.Char8 as BS
 import Data.Char (chr)
 import Data.List
@@ -30,13 +33,23 @@ import IC.Types
 import IC.Wasm.Winter (parseModule, exportedFunctions, Module)
 import qualified Wasm.Syntax.AST as W
 
-import Wasmtime hiding (Module)
+-- import Wasmtime hiding (Module)
 
 import IC.Purify
 import IC.Canister.Snapshot
 import IC.Canister.Imp
 import IC.Hash
 import IC.Utils
+
+import System.IO (BufferMode (NoBuffering), hSetBuffering, stdout)
+
+
+import Foreign.Marshal.Alloc (alloca, free, malloc, mallocBytes)
+import Foreign.Ptr (Ptr, castPtr, nullFunPtr, nullPtr, FunPtr)
+import Foreign.Marshal.Array (peekArray,pokeArray)
+import Foreign.Storable
+import Data.Word
+import Foreign.C.Types
 
 -- Here we can swap out the purification machinery
 type WasmState = CanisterSnapshot
@@ -79,6 +92,51 @@ decodeModule bytes =
     asmMagic = asBytes [0x00, 0x61, 0x73, 0x6d]
     gzipMagic = asBytes [0x1f, 0x8b, 0x08]
 
+data C'wasm_engine_t = C'wasm_engine_t
+data C'wasmtime_store = C'wasmtime_store
+type C'wasmtime_store_t = C'wasmtime_store
+data C'wasmtime_context = C'wasmtime_context
+type C'wasmtime_context_t = C'wasmtime_context
+data C'wasmtime_module = C'wasmtime_module
+type C'wasmtime_module_t = C'wasmtime_module
+data C'wasmtime_error = C'wasmtime_error
+type C'wasmtime_error_t = C'wasmtime_error
+data C'wasm_trap_t = C'wasm_trap_t
+data C'wasmtime_extern_t = C'wasmtime_extern_t
+
+data C'wasmtime_instance = C'wasmtime_instance{
+  c'wasmtime_instance'store_id :: Word64,
+  c'wasmtime_instance'index :: CSize
+} deriving (Eq,Show)
+instance Storable C'wasmtime_instance where
+  sizeOf _ = 16
+  alignment _ = 8
+  peek _p = do
+    v0 <- peekByteOff _p 0
+    v1 <- peekByteOff _p 8
+    return $ C'wasmtime_instance v0 v1
+  poke _p (C'wasmtime_instance v0 v1) = do
+    pokeByteOff _p 0 v0
+    pokeByteOff _p 8 v1
+    return ()
+
+type C'wasmtime_instance_t = C'wasmtime_instance
+
+foreign import ccall unsafe "wasm_engine_new" c'wasm_engine_new
+  :: IO (Ptr C'wasm_engine_t)
+
+foreign import ccall unsafe "wasmtime_store_new" c'wasmtime_store_new
+  :: Ptr C'wasm_engine_t -> Ptr a -> FunPtr (Ptr a -> IO ()) -> IO (Ptr C'wasmtime_store_t)
+
+foreign import ccall unsafe "wasmtime_store_context" c'wasmtime_store_context
+  :: Ptr C'wasmtime_store_t -> IO (Ptr C'wasmtime_context_t)
+
+foreign import ccall unsafe "wasmtime_module_new" c'wasmtime_module_new
+  :: Ptr C'wasm_engine_t -> Ptr Word8 -> CSize -> Ptr (Ptr C'wasmtime_module_t) -> IO (Ptr C'wasmtime_error_t)
+
+foreign import ccall unsafe "wasmtime_instance_new" c'wasmtime_instance_new
+  :: Ptr C'wasmtime_context_t -> Ptr C'wasmtime_module_t -> Ptr C'wasmtime_extern_t -> CSize -> Ptr C'wasmtime_instance_t -> Ptr (Ptr C'wasm_trap_t) -> IO (Ptr C'wasmtime_error_t)
+
 parseCanister :: Blob -> Either String CanisterModule
 parseCanister bytes = do
   decodedModule <- decodeModule bytes
@@ -102,23 +160,69 @@ parseCanister bytes = do
     , exports_heartbeat = "canister_heartbeat" `elem` exportedFunctions wasm_mod
     , exports_global_timer = "canister_global_timer" `elem` exportedFunctions wasm_mod
     , init_method = \caller env dat -> do
-          engine <- newEngine
-          store <- newStore engine
-          ctx <- storeContext store
-          myModule <- case newModule engine (unsafeWasmFromBytes $ BS.toStrict decodedModule) of
-                            Left err -> putStrLn (show err) >> error ""
-                            Right r -> return r
-          -- the following crashes
-          r <- newInstance ctx myModule (Vec.fromList [])
-          -- end
+          hSetBuffering stdout NoBuffering
+
+          engine_ptr <- c'wasm_engine_new
+          wasmtime_store_ptr <- c'wasmtime_store_new engine_ptr nullPtr nullFunPtr
+          ctx_ptr <- c'wasmtime_store_context wasmtime_store_ptr
+          let wasm = [0,97,115,109,1,0,0,0] :: [Word8]
+              n = length wasm
+          p <- mallocBytes n
+          pokeArray p wasm
+
+          module_ptr_ptr <- malloc
+          error_ptr <-
+            c'wasmtime_module_new
+              engine_ptr
+              p
+              (fromIntegral n)
+              module_ptr_ptr
+
+          print ("c'wasmtime_module_new: error_ptr", error_ptr)
+
+          mod_ptr <- peek module_ptr_ptr
+
+          putStrLn "Creating Instance ..."
+          (inst_ptr :: Ptr C'wasmtime_instance_t) <- malloc
+          (trap_ptr_ptr :: Ptr (Ptr C'wasm_trap_t)) <- malloc
+
+          error_ptr <-
+            c'wasmtime_instance_new
+              ctx_ptr
+              mod_ptr
+              nullPtr
+              0
+              inst_ptr
+              trap_ptr_ptr
+
+          print ("c'wasmtime_instance_new: error_ptr", error_ptr)
+
           putStrLn "done"
-          void $ case r of
-            Left err -> putStrLn (show err)
-            Right _ -> putStrLn "ok"
-          return $ case instantiate wasm_mod of
-            Trap err -> Trap err
-            Return wasm_state0 ->
-              invoke wasm_state0 (rawInitialize caller env dat)
+
+          trap_ptr <- peek trap_ptr_ptr
+
+          putStrLn "after peek"
+
+          if trap_ptr == nullPtr
+            then error "TODO"
+            else do
+              putStrLn "Received trap:"
+              print trap_ptr
+              error "TODO"
+
+          putStrLn "The impossible happened!"
+
+          error "another error!"
+
+          -- void $ case r of
+          --   Left trap -> do
+          --     putStrLn "Received trap:"
+          --     print trap
+          --   Right _ -> putStrLn "ok"
+          -- return $ case instantiate wasm_mod of
+          --   Trap err -> Trap err
+          --   Return wasm_state0 ->
+          --     invoke wasm_state0 (rawInitialize caller env dat)
     , update_methods = M.fromList
       [ (m,
         \caller env needs_to_respond cycles_available dat wasm_state ->

--- a/src/IC/Canister.hs
+++ b/src/IC/Canister.hs
@@ -108,7 +108,7 @@ parseCanister bytes = do
           engine <- newEngine
           store <- newStore engine
           ctx <- storeContext store
-          myModule <- case newModule engine (unsafeFromByteString $ BS.toStrict decodedModule) of
+          myModule <- case newModule engine (unsafeWasmFromBytes $ BS.toStrict decodedModule) of
                             Left err -> putStrLn (show err) >> error ""
                             Right r -> return r
           -- the following crashes

--- a/src/IC/Ref/Management.hs
+++ b/src/IC/Ref/Management.hs
@@ -218,7 +218,7 @@ icInstallCode caller r = do
       reinstall = do
         env <- canisterEnv canister_id
         let env1 = env { env_canister_version = env_canister_version env + 1, env_global_timer = 0 }
-        (wasm_state, ca) <- return (init_method new_can_mod caller env1 arg)
+        (wasm_state, ca) <- liftIO (init_method new_can_mod caller env1 arg)
           `onTrap` (\msg -> reject RC_CANISTER_ERROR ("Initialization trapped: " ++ msg) (Just EC_CANISTER_TRAPPED))
         setCanisterContent canister_id $ CanisterContent
             { can_mod = new_can_mod


### PR DESCRIPTION
We now have a standalone executable called `segfault` which exhibits the same segfault:

```
$ cabal run segfault
...
Linking /home/bas/d/ic-hs/mraszyk/init-io/dist-newstyle/build/x86_64-linux/ghc-9.2.8/ic-hs-0.0.1/x/segfault/build/segfault/segfault ...
("c'wasmtime_module_new: error_ptr",0x0000000000000000)
Creating Instance ...
("c'wasmtime_instance_new: error_ptr",0x0000000000000000)
done
after peek
Received trap:
0x0000000000af21e5
Segmentation fault (core dumped)
```