### PR TITLE
parse Boolean values in CBOR

### DIFF
--- a/src/IC/HTTP/CBOR.hs
+++ b/src/IC/HTTP/CBOR.hs
@@ -41,6 +41,7 @@ decode s =
     shorten n s = a <> (if T.null b then "" else "...")
         where (a,b) = T.splitAt n s
 
+    go (TBool b) = return $ GBool b
     go (TInt n) | n < 0 = Left "Negative integer"
     go (TInt n) = return $ GNat (fromIntegral n)
     go (TInteger n) | n < 0 = Left "Negative integer"

--- a/src/IC/HTTP/GenR.hs
+++ b/src/IC/HTTP/GenR.hs
@@ -16,7 +16,8 @@ import Data.ByteString.Lazy
 import Data.HashMap.Lazy
 
 data GenR
-    = GNat Natural
+    = GBool Bool
+    | GNat Natural
     | GText Text
     | GBlob ByteString
     | GRec (HashMap Text GenR)


### PR DESCRIPTION
Parsing Boolean values in CBOR is necessary now because `/api/v2/status` on the replica should return a Boolean valued field.