### PR TITLE
increase HTTP response timeout in ic-ref-test

### DIFF
--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -209,7 +209,7 @@ data AgentConfig = AgentConfig
 makeAgentConfig :: String -> String -> Int -> IO AgentConfig
 makeAgentConfig ep' httpbin' to = do
     manager <- newTlsManagerWith $ tlsManagerSettings
-      { managerResponseTimeout = responseTimeoutMicro 60_000_000 -- 60s
+      { managerResponseTimeout = responseTimeoutMicro 300_000_000 -- 300s
       }
     request <- parseRequest $ ep ++ "/api/v2/status"
     putStrLn $ "Fetching endpoint status from " ++ show ep ++ "..."


### PR DESCRIPTION
This PR should address ic-ref-test flakiness of the form:
```
2023-07-03 12:15:17.159 INFO[test:StdOut]         Exception: HttpExceptionRequest Request {
2023-07-03 12:15:17.159 INFO[test:StdOut]           host                 = "[2a0b:21c0:4003:2:5014:5eff:fe29:8571]"
2023-07-03 12:15:17.159 INFO[test:StdOut]           port                 = 8080
2023-07-03 12:15:17.159 INFO[test:StdOut]           secure               = False
2023-07-03 12:15:17.159 INFO[test:StdOut]           requestHeaders       = [("Content-Type","application/cbor")]
2023-07-03 12:15:17.159 INFO[test:StdOut]           path                 = "/api/v2/canister/rwlgt-iiaaa-aaaaa-aaaaa-cai/call"
2023-07-03 12:15:17.159 INFO[test:StdOut]           queryString          = ""
2023-07-03 12:15:17.159 INFO[test:StdOut]           method               = "POST"
2023-07-03 12:15:17.159 INFO[test:StdOut]           proxy                = Nothing
2023-07-03 12:15:17.159 INFO[test:StdOut]           rawBody              = False
2023-07-03 12:15:17.159 INFO[test:StdOut]           redirectCount        = 10
2023-07-03 12:15:17.159 INFO[test:StdOut]           responseTimeout      = ResponseTimeoutDefault
2023-07-03 12:15:17.159 INFO[test:StdOut]           requestVersion       = HTTP/1.1
2023-07-03 12:15:17.159 INFO[test:StdOut]           proxySecureMode      = ProxySecureWithConnect
2023-07-03 12:15:17.159 INFO[test:StdOut]         }
2023-07-03 12:15:17.159 INFO[test:StdOut]          ConnectionTimeout
```