### PR TITLE
check effective canister id against subnets' canister ranges

### DIFF
--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -122,6 +122,10 @@ type RequestValidation m = (MonadError ValidationError m, ICM m)
 
 authCallRequest :: RequestValidation m => Timestamp -> CanisterId -> EnvValidity -> CallRequest -> m ()
 authCallRequest t ecid ev r@(CallRequest canister_id user_id meth arg) = do
+    subnet <- getSubnetFromCanisterId' ecid
+    case subnet of
+      Nothing -> throwError $ HTTPError $ "Cannot route request with effective canister id " ++ prettyID ecid
+      _ -> return ()
     checkEffectiveCanisterID ecid canister_id meth arg
     res <- runExceptT $ do
         valid_when ev t
@@ -133,6 +137,10 @@ authCallRequest t ecid ev r@(CallRequest canister_id user_id meth arg) = do
 
 authQueryRequest :: RequestValidation m => Timestamp -> CanisterId -> EnvValidity -> QueryRequest -> m ()
 authQueryRequest t ecid ev (QueryRequest canister_id user_id meth arg) = do
+    subnet <- getSubnetFromCanisterId' ecid
+    case subnet of
+      Nothing -> throwError $ HTTPError $ "Cannot route request with effective canister id " ++ prettyID ecid
+      _ -> return ()
     checkEffectiveCanisterID ecid canister_id meth arg
     res <- runExceptT $ do
         valid_when ev t
@@ -143,6 +151,10 @@ authQueryRequest t ecid ev (QueryRequest canister_id user_id meth arg) = do
 
 authReadStateRequest :: RequestValidation m => Timestamp -> CanisterId -> EnvValidity -> ReadStateRequest -> m ()
 authReadStateRequest t ecid ev (ReadStateRequest user_id paths) = do
+    subnet <- getSubnetFromCanisterId' ecid
+    case subnet of
+      Nothing -> throwError $ HTTPError $ "Cannot route request with effective canister id " ++ prettyID ecid
+      _ -> return ()
     res <- runExceptT $ do
         valid_when ev t
         valid_for ev user_id

--- a/src/IC/Ref.hs
+++ b/src/IC/Ref.hs
@@ -123,9 +123,7 @@ type RequestValidation m = (MonadError ValidationError m, ICM m)
 authCallRequest :: RequestValidation m => Timestamp -> CanisterId -> EnvValidity -> CallRequest -> m ()
 authCallRequest t ecid ev r@(CallRequest canister_id user_id meth arg) = do
     subnet <- getSubnetFromCanisterId' ecid
-    case subnet of
-      Nothing -> throwError $ HTTPError $ "Cannot route request with effective canister id " ++ prettyID ecid
-      _ -> return ()
+    when (isNothing subnet) $ throwError $ HTTPError $ "Cannot route request with effective canister id " ++ prettyID ecid
     checkEffectiveCanisterID ecid canister_id meth arg
     res <- runExceptT $ do
         valid_when ev t
@@ -138,9 +136,7 @@ authCallRequest t ecid ev r@(CallRequest canister_id user_id meth arg) = do
 authQueryRequest :: RequestValidation m => Timestamp -> CanisterId -> EnvValidity -> QueryRequest -> m ()
 authQueryRequest t ecid ev (QueryRequest canister_id user_id meth arg) = do
     subnet <- getSubnetFromCanisterId' ecid
-    case subnet of
-      Nothing -> throwError $ HTTPError $ "Cannot route request with effective canister id " ++ prettyID ecid
-      _ -> return ()
+    when (isNothing subnet) $ throwError $ HTTPError $ "Cannot route request with effective canister id " ++ prettyID ecid
     checkEffectiveCanisterID ecid canister_id meth arg
     res <- runExceptT $ do
         valid_when ev t
@@ -152,9 +148,7 @@ authQueryRequest t ecid ev (QueryRequest canister_id user_id meth arg) = do
 authReadStateRequest :: RequestValidation m => Timestamp -> CanisterId -> EnvValidity -> ReadStateRequest -> m ()
 authReadStateRequest t ecid ev (ReadStateRequest user_id paths) = do
     subnet <- getSubnetFromCanisterId' ecid
-    case subnet of
-      Nothing -> throwError $ HTTPError $ "Cannot route request with effective canister id " ++ prettyID ecid
-      _ -> return ()
+    when (isNothing subnet) $ throwError $ HTTPError $ "Cannot route request with effective canister id " ++ prettyID ecid
     res <- runExceptT $ do
         valid_when ev t
         valid_for ev user_id

--- a/src/IC/Ref/Types.hs
+++ b/src/IC/Ref/Types.hs
@@ -223,7 +223,7 @@ onTrap a b = a >>= \case { Trap msg -> b msg; Return x -> return x }
 
 -- Helper functions
 
-getSubnetFromCanisterId' :: (CanReject m, ICM m) => CanisterId -> m (Maybe Subnet)
+getSubnetFromCanisterId' :: ICM m => CanisterId -> m (Maybe Subnet)
 getSubnetFromCanisterId' cid = do
   subnets <- gets subnets
   return $ find (\(_, _, _, _, ranges) -> checkCanisterIdInRanges ranges cid) subnets

--- a/src/IC/Test/Agent/UserCalls.hs
+++ b/src/IC/Test/Agent/UserCalls.hs
@@ -101,9 +101,9 @@ ic_raw_rand'' :: HasAgentConfig => Blob -> Blob -> IO (HTTPErrOr ReqResponse)
 ic_raw_rand'' user ecid = do
   callIC'' user ecid #raw_rand ()
 
-ic_http_get_request'' :: HasAgentConfig => Blob -> IO (HTTPErrOr ReqResponse)
-ic_http_get_request'' user =
-  callIC'' user "" #http_request $ empty
+ic_http_get_request'' :: HasAgentConfig => Blob -> Blob -> IO (HTTPErrOr ReqResponse)
+ic_http_get_request'' user ecid =
+  callIC'' user ecid #http_request $ empty
     .+ #url .== (T.pack $ "https://" ++ httpbin)
     .+ #max_response_bytes .== Nothing
     .+ #method .== enum #get

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -1094,7 +1094,7 @@ icTests my_sub other_sub =
             , "sender" =: GBlob defaultUser
             , "canister_id" =: GBlob ""
             , "method_name" =: GText "raw_rand"
-            , "arg" =: GBlob (Candid.encode R.empty)
+            , "arg" =: GBlob (Candid.encode ())
             ]
       addNonceExpiryEnv req >>= postCallCBOR "" >>= code4xx
 
@@ -1104,7 +1104,7 @@ icTests my_sub other_sub =
             , "sender" =: GBlob defaultUser
             , "canister_id" =: GBlob ""
             , "method_name" =: GText "raw_rand"
-            , "arg" =: GBlob (Candid.encode R.empty)
+            , "arg" =: GBlob (Candid.encode ())
             ]
       addNonceExpiryEnv req >>= postQueryCBOR "" >>= code4xx
 

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -1096,7 +1096,7 @@ icTests my_sub other_sub =
             , "method_name" =: GText "raw_rand"
             , "arg" =: GBlob (Candid.encode ())
             ]
-      addNonceExpiryEnv req >>= postCallCBOR "" >>= code4xx
+      addNonceExpiryEnv req >>= envelope defaultSK >>= postCallCBOR "" >>= code4xx
 
     , testCase "using management canister as effective canister id in query" $ do
       let req = rec
@@ -1106,7 +1106,7 @@ icTests my_sub other_sub =
             , "method_name" =: GText "raw_rand"
             , "arg" =: GBlob (Candid.encode ())
             ]
-      addNonceExpiryEnv req >>= postQueryCBOR "" >>= code4xx
+      addNonceExpiryEnv req >>= envelope defaultSK >>= postQueryCBOR "" >>= code4xx
 
     , testCase "using management canister as effective canister id in read_state" $ do
       let req = rec
@@ -1114,7 +1114,7 @@ icTests my_sub other_sub =
             , "sender" =: GBlob defaultUser
             , "paths" =: GList [GList [GBlob "time"]]
             ]
-      addExpiry req >>= envelope defaultSK >>= postReadStateCBOR "" >>= code4xx
+      addNonceExpiry req >>= envelope defaultSK >>= postReadStateCBOR "" >>= code4xx
     ]
 
   , testGroup "inter-canister calls"

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -1096,7 +1096,7 @@ icTests my_sub other_sub =
             , "method_name" =: GText "raw_rand"
             , "arg" =: GBlob (Candid.encode ())
             ]
-      addNonceExpiryEnv req >>= envelope defaultSK >>= postCallCBOR "" >>= code4xx
+      addNonceExpiryEnv req >>= postCallCBOR "" >>= code4xx
 
     , testCase "using management canister as effective canister id in query" $ do
       let req = rec
@@ -1106,7 +1106,7 @@ icTests my_sub other_sub =
             , "method_name" =: GText "raw_rand"
             , "arg" =: GBlob (Candid.encode ())
             ]
-      addNonceExpiryEnv req >>= envelope defaultSK >>= postQueryCBOR "" >>= code4xx
+      addNonceExpiryEnv req >>= postQueryCBOR "" >>= code4xx
 
     , testCase "using management canister as effective canister id in read_state" $ do
       let req = rec
@@ -1114,7 +1114,7 @@ icTests my_sub other_sub =
             , "sender" =: GBlob defaultUser
             , "paths" =: GList [GList [GBlob "time"]]
             ]
-      addNonceExpiry req >>= envelope defaultSK >>= postReadStateCBOR "" >>= code4xx
+      addNonceExpiryEnv req >>= postReadStateCBOR "" >>= code4xx
     ]
 
   , testGroup "inter-canister calls"

--- a/src/IC/Test/Spec.hs
+++ b/src/IC/Test/Spec.hs
@@ -1087,6 +1087,34 @@ icTests my_sub other_sub =
             ]
       let path = "/api/v2/canister/" ++ filter (/= '-') (textual cid1) ++ "/call"
       addNonceExpiryEnv req >>= postCBOR path >>= code4xx
+
+    , testCase "using management canister as effective canister id in update" $ do
+      let req = rec
+            [ "request_type" =: GText "call"
+            , "sender" =: GBlob defaultUser
+            , "canister_id" =: GBlob ""
+            , "method_name" =: GText "raw_rand"
+            , "arg" =: GBlob (Candid.encode R.empty)
+            ]
+      addNonceExpiryEnv req >>= postCallCBOR "" >>= code4xx
+
+    , testCase "using management canister as effective canister id in query" $ do
+      let req = rec
+            [ "request_type" =: GText "query"
+            , "sender" =: GBlob defaultUser
+            , "canister_id" =: GBlob ""
+            , "method_name" =: GText "raw_rand"
+            , "arg" =: GBlob (Candid.encode R.empty)
+            ]
+      addNonceExpiryEnv req >>= postQueryCBOR "" >>= code4xx
+
+    , testCase "using management canister as effective canister id in read_state" $ do
+      let req = rec
+            [ "request_type" =: GText "read_state"
+            , "sender" =: GBlob defaultUser
+            , "paths" =: GList [GList [GBlob "time"]]
+            ]
+      addExpiry req >>= envelope defaultSK >>= postReadStateCBOR "" >>= code4xx
     ]
 
   , testGroup "inter-canister calls"
@@ -2363,7 +2391,7 @@ icTests my_sub other_sub =
       ic_raw_rand'' defaultUser ecid >>= isNoErrReject [4]
 
     , testCase "management canister: http_request not accepted" $ do
-      ic_http_get_request'' defaultUser >>= isNoErrReject [4]
+      ic_http_get_request'' defaultUser ecid >>= isNoErrReject [4]
 
     , testCase "management canister: ecdsa_public_key not accepted" $ do
       ic_ecdsa_public_key'' defaultUser ecid >>= isNoErrReject [4]


### PR DESCRIPTION
The effective canister ID in the URL of every request (update, query, read state request) must be contained in the canister ranges of a subnet (so that the request can be properly routed to that subnet by the BN in the mainnet implementation). This PR checks that condition in the reference implementation, fixes a test that did not satisfy the condition, and also adds tests that explicitly test for that condition.

Note. The conditions on effective canister IDs are specified in this [section](https://ic-interface-spec.netlify.app/docs/#http-effective-canister-id) of the Interface Specification and should be updated, too.