### PR TITLE
sync node height before making an update call in compliance tests

### DIFF
--- a/src/IC/Test/Agent.hs
+++ b/src/IC/Test/Agent.hs
@@ -433,7 +433,7 @@ postReadStateCBOR' :: (HasCallStack, HasAgentConfig) => String -> Blob -> GenR -
 postReadStateCBOR' ep cid = postCBOR' ep $ "/api/v2/canister/" ++ textual cid ++ "/read_state"
 
 postCallCBOR, postQueryCBOR, postReadStateCBOR :: (HasCallStack, HasAgentConfig) => Blob -> GenR -> IO (Response BS.ByteString)
-postCallCBOR cid      = postCBOR $ "/api/v2/canister/" ++ textual cid ++ "/call"
+postCallCBOR cid      = (\r -> sync_height cid >> postCBOR ("/api/v2/canister/" ++ textual cid ++ "/call") r)
 postQueryCBOR cid     = (\r -> sync_height cid >> postCBOR ("/api/v2/canister/" ++ textual cid ++ "/query") r)
 postReadStateCBOR cid = (\r -> sync_height cid >> postReadStateCBOR' endPoint cid r)
 


### PR DESCRIPTION
When using BNs in the IC topology of system tests, we need to sync node height even before making an update call because the `inspect_message` call (that precedes the actual replicated update method execution) is executed non-replicated and thus its outcome depends on all nodes being up-to-date.